### PR TITLE
rails_helper に必要な設定を記述

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+Faker::Config.locale = :ja
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -61,4 +62,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
## 概要
- `rails_helper.rb`に factory_bot の省略設定と Faker の日本語設定を記述する
## タスク内容
- `rails_helper.rb`ファイルの `RSpec.configure do |config|` 以下に `config.include FactoryBot::Syntax::Methods`という記述を追加
- `rails_helper.rb`ファイルの`require 'rspec/rails'`の次の行に`Faker::Config.locale = :ja`という記述を追加

## チェックリスト

- [x] GitHub の Files changed で差分を確認
- [x] 影響し得る範囲のローカル環境での動作確認
