### PR TITLE
UserDirectory モデルのバリデーション、テストの作成

### DIFF
--- a/app/models/user_directory.rb
+++ b/app/models/user_directory.rb
@@ -22,4 +22,6 @@ class UserDirectory < ApplicationRecord
   belongs_to :user
   has_many :documents, dependent: :nullify
   has_ancestry
+
+  validates :name, length: {maximum: 20}
 end

--- a/app/models/user_directory.rb
+++ b/app/models/user_directory.rb
@@ -21,4 +21,5 @@
 class UserDirectory < ApplicationRecord
   belongs_to :user
   has_many :documents, dependent: :nullify
+  has_ancestry
 end

--- a/app/models/user_directory.rb
+++ b/app/models/user_directory.rb
@@ -3,6 +3,7 @@
 # Table name: user_directories
 #
 #  id         :bigint           not null, primary key
+#  ancestry   :string
 #  name       :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -10,7 +11,8 @@
 #
 # Indexes
 #
-#  index_user_directories_on_user_id  (user_id)
+#  index_user_directories_on_ancestry  (ancestry)
+#  index_user_directories_on_user_id   (user_id)
 #
 # Foreign Keys
 #

--- a/app/models/user_directory.rb
+++ b/app/models/user_directory.rb
@@ -23,5 +23,5 @@ class UserDirectory < ApplicationRecord
   has_many :documents, dependent: :nullify
   has_ancestry
 
-  validates :name, length: {maximum: 20}
+  validates :name, length: {maximum: 20}, presence: true
 end

--- a/app/models/user_directory.rb
+++ b/app/models/user_directory.rb
@@ -23,5 +23,5 @@ class UserDirectory < ApplicationRecord
   has_many :documents, dependent: :nullify
   has_ancestry
 
-  validates :name, length: {maximum: 20}, presence: true
+  validates :name, length: { maximum: 20 }, presence: true
 end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -45,8 +45,7 @@ RSpec/InstanceVariable:
 # パフォーマンスの問題さえ無ければ 1 example 1 assertion にしておく方が
 # 読みやすいテストになりやすいので、そこはレビューで担保していく必要がある。
 RSpec/MultipleExpectations:
-  Max: 2
-  AggregateFailuresByDefault: true
+  Enabled: false
 
 # 変に名前つけて呼ぶ方が分かりづらい。
 # テスト対象メソッドを呼ぶだけの subject 以外を書かないようにする方が効く。

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -45,6 +45,7 @@ RSpec/InstanceVariable:
 # パフォーマンスの問題さえ無ければ 1 example 1 assertion にしておく方が
 # 読みやすいテストになりやすいので、そこはレビューで担保していく必要がある。
 RSpec/MultipleExpectations:
+  Max: 2
   AggregateFailuresByDefault: true
 
 # 変に名前つけて呼ぶ方が分かりづらい。

--- a/db/migrate/20210420235500_add_ancestry_to_user_directory.rb
+++ b/db/migrate/20210420235500_add_ancestry_to_user_directory.rb
@@ -1,0 +1,6 @@
+class AddAncestryToUserDirectory < ActiveRecord::Migration[6.1]
+  def change
+    add_column :user_directories, :ancestry, :string
+    add_index :user_directories, :ancestry
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_19_151047) do
+ActiveRecord::Schema.define(version: 2021_04_20_235500) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,8 @@ ActiveRecord::Schema.define(version: 2021_04_19_151047) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "ancestry"
+    t.index ["ancestry"], name: "index_user_directories_on_ancestry"
     t.index ["user_id"], name: "index_user_directories_on_user_id"
   end
 

--- a/spec/factories/user_directories.rb
+++ b/spec/factories/user_directories.rb
@@ -3,6 +3,7 @@
 # Table name: user_directories
 #
 #  id         :bigint           not null, primary key
+#  ancestry   :string
 #  name       :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -10,7 +11,8 @@
 #
 # Indexes
 #
-#  index_user_directories_on_user_id  (user_id)
+#  index_user_directories_on_ancestry  (ancestry)
+#  index_user_directories_on_user_id   (user_id)
 #
 # Foreign Keys
 #

--- a/spec/factories/user_directories.rb
+++ b/spec/factories/user_directories.rb
@@ -21,7 +21,7 @@
 FactoryBot.define do
   factory :user_directory do
     name { "MyString" }
-    user { nil }
-    user_directory { nil }
+    user
+    ancestry { nil }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -20,5 +20,8 @@
 #
 FactoryBot.define do
   factory :user do
+    name { Faker::Name.unique.first_name }
+    email { Faker::Internet.unique.email }
+    password { Faker::Internet.password(min_length: 8) }
   end
 end

--- a/spec/models/user_directory_spec.rb
+++ b/spec/models/user_directory_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe UserDirectory, type: :model do
     context "name が21文字以上のとき" do
       let(:user_directory) { build(:user_directory, name: "ディレクトリ" * 30) }
       it "ユーザーディレクトリが作られない" do
-        expect(subject).to_not be_valid
+        expect(subject).not_to be_valid
         expect(subject.errors.details[:name][0][:error]).to eq :too_long
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe UserDirectory, type: :model do
     context "name が空のとき" do
       let(:user_directory) { build(:user_directory, name: "") }
       it "ユーザーディレクトリが作られない" do
-        expect(subject).to_not be_valid
+        expect(subject).not_to be_valid
         expect(subject.errors.details[:name][0][:error]).to eq :blank
       end
     end
@@ -50,7 +50,7 @@ RSpec.describe UserDirectory, type: :model do
     context "user_id が空のとき" do
       let(:user_directory) { build(:user_directory, user_id: nil) }
       it "ユーザーディレクトリが作られない" do
-        expect(subject).to_not be_valid
+        expect(subject).not_to be_valid
         expect(subject.errors.details[:user][0][:error]).to eq :blank
       end
     end

--- a/spec/models/user_directory_spec.rb
+++ b/spec/models/user_directory_spec.rb
@@ -21,5 +21,38 @@
 require "rails_helper"
 
 RSpec.describe UserDirectory, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "バリデーションのチェック" do
+    subject { user_directory.valid? }
+
+    context "name が２０文字以内のとき" do
+      let(:user_directory) { build(:user_directory) }
+      it "ユーザーディレクトリが作られる" do
+        expect(subject).to eq true
+      end
+    end
+
+    context "name が２０文字以上のとき" do
+      let(:user_directory) { build(:user_directory, name: "ディレクトリ" * 30) }
+      it "ユーザーディレクトリが作られない" do
+        expect(subject).to eq false
+        expect(user_directory.errors.details[:name][0][:error]).to eq :too_long
+      end
+    end
+
+    context "name が空のとき" do
+      let(:user_directory) { build(:user_directory, name: "") }
+      it "ユーザーディレクトリが作られない" do
+        expect(subject).to eq false
+        expect(user_directory.errors.details[:name][0][:error]).to eq :blank
+      end
+    end
+
+    context "user_id が空のとき" do
+      let(:user_directory) { build(:user_directory, user_id: "") }
+      it "ユーザーディレクトリが作られない" do
+        expect(subject).to eq false
+        expect(user_directory.errors.details[:user][0][:error]).to eq :blank
+      end
+    end
+  end
 end

--- a/spec/models/user_directory_spec.rb
+++ b/spec/models/user_directory_spec.rb
@@ -3,6 +3,7 @@
 # Table name: user_directories
 #
 #  id         :bigint           not null, primary key
+#  ancestry   :string
 #  name       :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -10,7 +11,8 @@
 #
 # Indexes
 #
-#  index_user_directories_on_user_id  (user_id)
+#  index_user_directories_on_ancestry  (ancestry)
+#  index_user_directories_on_user_id   (user_id)
 #
 # Foreign Keys
 #

--- a/spec/models/user_directory_spec.rb
+++ b/spec/models/user_directory_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe UserDirectory, type: :model do
   describe "バリデーションのチェック" do
     subject { user_directory }
 
-    context "name が２０文字以内のとき" do
+    context "name が20文字以下のとき" do
       let(:user_directory) { build(:user_directory) }
       it "ユーザーディレクトリが作られる" do
         expect(subject).to be_valid
       end
     end
 
-    context "name が２０文字以上のとき" do
+    context "name が21文字以上のとき" do
       let(:user_directory) { build(:user_directory, name: "ディレクトリ" * 30) }
       it "ユーザーディレクトリが作られない" do
         expect(subject).to_not be_valid

--- a/spec/models/user_directory_spec.rb
+++ b/spec/models/user_directory_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe UserDirectory, type: :model do
     end
 
     context "name が空のとき" do
-      let(:user_directory) { build(:user_directory, name: "") }
+      let(:user_directory) { build(:user_directory, name: nil) }
       it "ユーザーディレクトリが作られない" do
         expect(subject).not_to be_valid
         expect(subject.errors.details[:name][0][:error]).to eq :blank

--- a/spec/models/user_directory_spec.rb
+++ b/spec/models/user_directory_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe UserDirectory, type: :model do
     end
 
     context "name が21文字以上のとき" do
-      let(:user_directory) { build(:user_directory, name: "ディレクトリ" * 30) }
+      let(:user_directory) { build(:user_directory, name: "A" * 21) }
       it "ユーザーディレクトリが作られない" do
         expect(subject).not_to be_valid
         expect(subject.errors.details[:name][0][:error]).to eq :too_long

--- a/spec/models/user_directory_spec.rb
+++ b/spec/models/user_directory_spec.rb
@@ -22,36 +22,36 @@ require "rails_helper"
 
 RSpec.describe UserDirectory, type: :model do
   describe "バリデーションのチェック" do
-    subject { user_directory.valid? }
+    subject { user_directory }
 
     context "name が２０文字以内のとき" do
       let(:user_directory) { build(:user_directory) }
       it "ユーザーディレクトリが作られる" do
-        expect(subject).to eq true
+        expect(subject).to be_valid
       end
     end
 
     context "name が２０文字以上のとき" do
       let(:user_directory) { build(:user_directory, name: "ディレクトリ" * 30) }
       it "ユーザーディレクトリが作られない" do
-        expect(subject).to eq false
-        expect(user_directory.errors.details[:name][0][:error]).to eq :too_long
+        expect(subject).to_not be_valid
+        expect(subject.errors.details[:name][0][:error]).to eq :too_long
       end
     end
 
     context "name が空のとき" do
       let(:user_directory) { build(:user_directory, name: "") }
       it "ユーザーディレクトリが作られない" do
-        expect(subject).to eq false
-        expect(user_directory.errors.details[:name][0][:error]).to eq :blank
+        expect(subject).to_not be_valid
+        expect(subject.errors.details[:name][0][:error]).to eq :blank
       end
     end
 
     context "user_id が空のとき" do
-      let(:user_directory) { build(:user_directory, user_id: "") }
+      let(:user_directory) { build(:user_directory, user_id: nil) }
       it "ユーザーディレクトリが作られない" do
-        expect(subject).to eq false
-        expect(user_directory.errors.details[:user][0][:error]).to eq :blank
+        expect(subject).to_not be_valid
+        expect(subject.errors.details[:user][0][:error]).to eq :blank
       end
     end
   end


### PR DESCRIPTION
## 概要
- UserDirectoryモデルに関するバリデーションとテストコードの実装
- Ancestry Gem の導入

## タスク内容
### Ancestry Gem の導入
- `Gemfile` に`ancestry` を追記してインストール
- `ancestry`を使えるように`user_directory.rb`に追記

### バリデーションの設定
- `user_directory.rb`の nameカラムにバリデーションを追加
  - 文字数は20文字以内
  - 入力必須

### テストの作成
以下の項目についてテストを作成しました。

- 正常系
  - name が20文字以内のとき
- 異常系
  - nameが20文字以上のとき
  - nameが空のとき
  - user_id が空のとき

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub の Files changed で差分を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## その他参考情報
### 実装する上で参考にしたサイト
- [【Rails】「テーブルのカラムに定義するNot Null制約」と「モデルに定義するバリデーション（presence: true）」の挙動の違い。](https://qiita.com/wonder_meet/items/fa804f0d436a29c97460)

### その他
- 他にも必要なテスト項目あれば教えてください。
