### PR TITLE
Document_image モデルのバリデーションの設定とテスト実装

### DIFF
--- a/app/models/document_image.rb
+++ b/app/models/document_image.rb
@@ -18,4 +18,5 @@
 #
 class DocumentImage < ApplicationRecord
   belongs_to :document
+  validates :image, presence: true
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -23,5 +23,6 @@ FactoryBot.define do
   factory :comment do
     body { Faker::Lorem.sentence }
     user
+    document
   end
 end

--- a/spec/factories/document_images.rb
+++ b/spec/factories/document_images.rb
@@ -18,7 +18,7 @@
 #
 FactoryBot.define do
   factory :document_image do
-    image { "MyString" }
-    document { nil }
+    image { Faker::Internet.url }
+    document
   end
 end

--- a/spec/factories/document_images.rb
+++ b/spec/factories/document_images.rb
@@ -18,7 +18,7 @@
 #
 FactoryBot.define do
   factory :document_image do
-    image { Faker::Internet.url }
+    image { Faker::File.mime_type }
     document
   end
 end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -27,5 +27,8 @@ FactoryBot.define do
   factory :document do
     title { Faker::Game.title }
     body { Faker::Lorem.sentence }
+    user_directory
+    writer { user_directory.user }
+    owner { user_directory.user }
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -25,18 +25,15 @@ RSpec.describe Comment, type: :model do
   describe "バリデーションのチェック" do
     subject { comment }
 
-    let(:user) { create(:user) }
-    let(:user_directory) { create(:user_directory, user: user) }
-    let(:document) { create(:document, writer: user, owner: user, user_directory: user_directory) }
     context "body がある時" do
-      let(:comment) { build(:comment, document: document) }
+      let(:comment) { build(:comment) }
       it "コメント登録される" do
         expect(subject).to be_valid
       end
     end
 
     context "body がない時" do
-      let(:comment) { build(:comment, body: nil, document: document) }
+      let(:comment) { build(:comment, body: nil) }
       it "コメント登録できない" do
         expect(subject).not_to be_valid
         expect(subject.errors.details[:body][0][:error]).to eq :blank

--- a/spec/models/document_image_spec.rb
+++ b/spec/models/document_image_spec.rb
@@ -19,5 +19,22 @@
 require "rails_helper"
 
 RSpec.describe DocumentImage, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "バリデーションのテスト" do
+    subject { document_image }
+
+    context "image が存在する時" do
+      let(:document_image) { build(:document_image) }
+      it "document_image が登録される" do
+        expect(subject).to be_valid
+      end
+    end
+
+    context "image が存在しない時" do
+      let(:document_image) { build(:document_image, image: nil) }
+      it "document_image は登録できない" do
+        expect(subject).not_to be_valid
+        expect(subject.errors.details[:image][0][:error]).to eq :blank
+      end
+    end
+  end
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -29,18 +29,15 @@ RSpec.describe Document, type: :model do
   describe "バリデーションのチェック" do
     subject { document }
 
-    let(:user) { create(:user, name: "NAME", email: "sample@example.com", password: "sample12") }
-    let(:user_directory) { create(:user_directory, name: "user1", user_id: user.id) }
-
     context "title が50文字以内のとき" do
-      let(:document) { build(:document, user_directory: user_directory, writer: user, owner: user) }
+      let(:document) { build(:document, title: "A" * 50) }
       it "Documentを保存する" do
         expect(subject).to be_valid
       end
     end
 
     context "title が51文字以上のとき" do
-      let(:document) { build(:document, user_directory: user_directory, writer: user, owner: user, title: "A" * 51) }
+      let(:document) { build(:document, title: "A" * 51) }
       it "Documentを保存されない" do
         expect(subject).not_to be_valid
         expect(subject.errors.details[:title][0][:error]).to eq :too_long
@@ -48,7 +45,7 @@ RSpec.describe Document, type: :model do
     end
 
     context "title が空のとき" do
-      let(:document) { build(:document, user_directory: user_directory, writer: user, owner: user, title: nil) }
+      let(:document) { build(:document, title: nil) }
       it "Documentを保存されない" do
         expect(subject).not_to be_valid
         expect(subject.errors.details[:title][0][:error]).to eq :blank


### PR DESCRIPTION
## 概要
- Document_image モデルのバリデーションの設定とテスト実装

## タスク内容
- Document_image モデルのバリデーションを設定
- `spec/factories/document_images.rb`の内容変更
- Document_image モデルのテスト実装
- `spec/factories`の内容が固まったため、Document モデルと Comment モデルのテスト実装をリファクタリング

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub の Files changed で差分を確認
- [x] 影響し得る範囲のローカル環境での動作確認
