### PR TITLE
show action のドキュメントを current_user から取り出すように設定変更

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,6 +1,6 @@
 class DocumentsController < ApplicationController
   def show
-    @document = current_user.documents.find(params[:id])
+    @document = current_user.have_documents.find(params[:id])
     @directory = @document.user_directory.path.pluck(:name)
   end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,6 +1,6 @@
 class DocumentsController < ApplicationController
   def show
-    @document = Document.find(params[:id])
+    @document = current_user.documents.find(params[:id])
     @directory = @document.user_directory.path.pluck(:name)
   end
 end


### PR DESCRIPTION
## 概要
- show action のドキュメントを current_user から取り出すように設定変更

## タスク内容
- documents_controller のshow メソッド内でのドキュメントの取り出し方を,Document モデルからではなく、 current_user からに変更

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub の Files changed で差分を確認
- [x] 影響し得る範囲のローカル環境での動作確認
