### PR TITLE
サイドバーの実装

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,6 +10,7 @@ import "channels";
 import "bootstrap";
 import "../src/application.scss";
 import marked from "marked";
+import "@fortawesome/fontawesome-free/js/all";
 
 window.marked = marked;
 

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -35,3 +35,4 @@ ul {
 .area {
   display: none;
 }
+@import '~@fortawesome/fontawesome-free/scss/fontawesome';

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -36,16 +36,22 @@ ul {
   display: none;
 }
 @import '~@fortawesome/fontawesome-free/scss/fontawesome';
-
-.documents_sidebar {
-  font-size: 0.8rem;
-  width: 80px;
-  min-height: 100vh;
-
-  .fa-pen-nib {
-    font-size: 2.5rem;
+.root_container {
+  display: flex;
+  width: 100%;
+  .big_container {
+    width: 100%;
   }
-  .fa-book {
-    font-size: 2.5rem;
+  .documents_sidebar {
+    font-size: 0.8rem;
+    width: 80px;
+    min-height: 100vh;
+
+    .fa-pen-nib {
+      font-size: 2.5rem;
+    }
+    .fa-book {
+      font-size: 2.5rem;
+    }
   }
 }

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -36,3 +36,13 @@ ul {
   display: none;
 }
 @import '~@fortawesome/fontawesome-free/scss/fontawesome';
+
+.documents_sidebar {
+  font-size: 0.8rem;
+  .fa-pen-nib {
+    font-size: 2.5rem;
+  }
+  .fa-book {
+    font-size: 2.5rem;
+  }
+}

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -37,20 +37,15 @@ ul {
 }
 @import '~@fortawesome/fontawesome-free/scss/fontawesome';
 
-html {
-  height: 100%;
-  body {
-    height: 100%;
-    .documents_sidebar {
-      font-size: 0.8rem;
-      width: 80px;
+.documents_sidebar {
+  font-size: 0.8rem;
+  width: 80px;
+  min-height: 100vh;
 
-      .fa-pen-nib {
-        font-size: 2.5rem;
-      }
-      .fa-book {
-        font-size: 2.5rem;
-      }
-    }
+  .fa-pen-nib {
+    font-size: 2.5rem;
+  }
+  .fa-book {
+    font-size: 2.5rem;
   }
 }

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -43,6 +43,8 @@ html {
     height: 100%;
     .documents_sidebar {
       font-size: 0.8rem;
+      width: 80px;
+
       .fa-pen-nib {
         font-size: 2.5rem;
       }

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -37,12 +37,18 @@ ul {
 }
 @import '~@fortawesome/fontawesome-free/scss/fontawesome';
 
-.documents_sidebar {
-  font-size: 0.8rem;
-  .fa-pen-nib {
-    font-size: 2.5rem;
-  }
-  .fa-book {
-    font-size: 2.5rem;
+html {
+  height: 100%;
+  body {
+    height: 100%;
+    .documents_sidebar {
+      font-size: 0.8rem;
+      .fa-pen-nib {
+        font-size: 2.5rem;
+      }
+      .fa-book {
+        font-size: 2.5rem;
+      }
+    }
   }
 }

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -1,30 +1,37 @@
-<div class="container">
-  <div class="row border-bottom mt-5 pb-3">
-    <div class="col col-8">
-      <div class="pb-2">
-        <%= @directory.join("/") %>
-      </div>
-      <h1>
-        <%= @document.title %>
-      </h1>
-    </div>
-    <div class="col col-4 text-center">
-      <div class="pt-3">
-        作成日:<%=  @document.created_at.to_s(:datetime_jp) %>
-      </div>
-      <div>
-        更新日:<%=  @document.updated_at.to_s(:datetime_jp) %>
-      </div>
-    </div>
+<div class="row h-100">
+  <div class="col col-1">
+    <%= render partial: "layouts/documents_sidebar" %>
   </div>
-  <div class="row mt-5">
-    <div class="col">
-      <div id="content"></div>
-      <div id="mdraw" class="d-none">
-        <%= @document.body %>
+  <div class="col col-11">
+    <div class="container">
+      <div class="row border-bottom mt-5 pb-3">
+        <div class="col col-8">
+          <div class="pb-2">
+            <%= @directory.join("/") %>
+          </div>
+          <h1>
+            <%= @document.title %>
+          </h1>
+        </div>
+        <div class="col col-4 text-center">
+          <div class="pt-3">
+            作成日:<%=  @document.created_at.to_s(:datetime_jp) %>
+          </div>
+          <div>
+            更新日:<%=  @document.updated_at.to_s(:datetime_jp) %>
+          </div>
+        </div>
+      </div>
+      <div class="row mt-5">
+        <div class="col">
+          <div id="content"></div>
+          <div id="mdraw" class="d-none">
+            <%= @document.body %>
+          </div>
+        </div>
       </div>
     </div>
+    <%= link_to 'ログアウト', destroy_user_session_path, method: :delete %>
   </div>
 </div>
-<%= link_to 'ログアウト', destroy_user_session_path, method: :delete %>
 <%= javascript_pack_tag 'documents/show' %>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -20,9 +20,7 @@
   <div class="row mt-5">
     <div class="col">
       <div id="content"></div>
-      <div id="mdraw" class="d-none">
-        <%= @document.body %>
-      </div>
+      <div id="mdraw" class="d-none"><%= @document.body %></div>
     </div>
   </div>
 </div>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -1,37 +1,30 @@
-<div class="row h-100">
-  <div class="col col-2">
-    <%= render partial: "layouts/documents_sidebar" %>
-  </div>
-  <div class="col col-10">
-    <div class="container">
-      <div class="row border-bottom mt-5 pb-3">
-        <div class="col col-8">
-          <div class="pb-2">
-            <%= @directory.join("/") %>
-          </div>
-          <h1>
-            <%= @document.title %>
-          </h1>
-        </div>
-        <div class="col col-4 text-center">
-          <div class="pt-3">
-            作成日:<%=  @document.created_at.to_s(:datetime_jp) %>
-          </div>
-          <div>
-            更新日:<%=  @document.updated_at.to_s(:datetime_jp) %>
-          </div>
-        </div>
+<div class="container">
+  <div class="row border-bottom mt-5 pb-3">
+    <div class="col col-8">
+      <div class="pb-2">
+        <%= @directory.join("/") %>
       </div>
-      <div class="row mt-5">
-        <div class="col">
-          <div id="content"></div>
-          <div id="mdraw" class="d-none">
-            <%= @document.body %>
-          </div>
-        </div>
+      <h1>
+        <%= @document.title %>
+      </h1>
+    </div>
+    <div class="col col-4 text-center">
+      <div class="pt-3">
+        作成日:<%=  @document.created_at.to_s(:datetime_jp) %>
+      </div>
+      <div>
+        更新日:<%=  @document.updated_at.to_s(:datetime_jp) %>
       </div>
     </div>
-    <%= link_to 'ログアウト', destroy_user_session_path, method: :delete %>
+  </div>
+  <div class="row mt-5">
+    <div class="col">
+      <div id="content"></div>
+      <div id="mdraw" class="d-none">
+        <%= @document.body %>
+      </div>
+    </div>
   </div>
 </div>
+<%= link_to 'ログアウト', destroy_user_session_path, method: :delete %>
 <%= javascript_pack_tag 'documents/show' %>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -1,8 +1,8 @@
 <div class="row h-100">
-  <div class="col col-1">
+  <div class="col col-2">
     <%= render partial: "layouts/documents_sidebar" %>
   </div>
-  <div class="col col-11">
+  <div class="col col-10">
     <div class="container">
       <div class="row border-bottom mt-5 pb-3">
         <div class="col col-8">

--- a/app/views/layouts/_documents_sidebar.html.erb
+++ b/app/views/layouts/_documents_sidebar.html.erb
@@ -6,7 +6,7 @@
     <% end %>
   </div>
   <div class="pt-4">
-    <%= link_to document_path, class: "text-decoration-none text-white" do %>
+    <%= link_to documents_path, class: "text-decoration-none text-white" do %>
     <i class="fas fa-book pb-1"></i><br>
     ドキュメント一覧<br>
     <% end %>

--- a/app/views/layouts/_documents_sidebar.html.erb
+++ b/app/views/layouts/_documents_sidebar.html.erb
@@ -1,0 +1,14 @@
+<div class="documents_sidebar bg-primary text-center h-100">
+  <div class="pt-4">
+    <%= link_to new_document_path, class: "text-decoration-none text-white" do %>
+    <i class="fas fa-pen-nib pb-1"></i><br>
+    ドキュメント作成<br>
+    <% end %>
+  </div>
+  <div class="pt-4">
+    <%= link_to document_path, class: "text-decoration-none text-white" do %>
+    <i class="fas fa-book pb-1"></i><br>
+    ドキュメント一覧<br>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,18 @@
 </head>
 
 <body>
+  <% if user_signed_in? %>
+  <div class="row h-100">
+    <div class="col col-2">
+      <%= render "layouts/documents_sidebar" %>
+    </div>
+    <div class="col col-10">
+      <%= yield %>
+    </div>
+  </div>
+  <% else %>
   <%= yield %>
+  <% end %>
 </body>
 
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,18 +11,14 @@
 </head>
 
 <body>
-  <% if user_signed_in? %>
-  <div class="row h-100">
-    <div class="col col-2">
-      <%= render "layouts/documents_sidebar" %>
-    </div>
-    <div class="col col-10">
+  <div class="root_container">
+    <% if user_signed_in? %>
+    <%= render "layouts/documents_sidebar" %>
+    <% end %>
+    <div class="big_container">
       <%= yield %>
     </div>
   </div>
-  <% else %>
-  <%= yield %>
-  <% end %>
 </body>
 
 </html>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "wonderful-portal",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.15.3",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -848,6 +848,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@fortawesome/fontawesome-free@^5.15.3":
+  version "5.15.3"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.3.tgz#c36ffa64a2a239bf948541a97b6ae8d729e09a9a"
+  integrity sha512-rFnSUN/QOtnOAgqFRooTA3H57JLDm0QEG/jPdk+tLQNL/eWd+Aok8g3qCI+Q1xuDPWpGW/i9JySpJVsq8Q0s9w==
+
 "@npmcli/move-file@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.1.2.tgz#1a82c3e372f7cae9253eb66d72543d6b8685c674"


### PR DESCRIPTION
## 概要
- 部分テンプレートを使ってサイドバーを実装


## タスク内容
- Font Awesome を導入
- サイドバー用の部分テンプレートファイルを作成
- サイドバーの実装
- 記事詳細ページにてサイドバーの部分テンプレートを呼び出し

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub の Files changed で差分を確認
- [x] 影響し得る範囲のローカル環境での動作確認


## 実装画面
![スクリーンショット 2021-05-02 23 50 34](https://user-images.githubusercontent.com/77535025/116817534-c1890980-aba1-11eb-8397-231f62277de2.png)

## その他参考情報
### 実装する上で参考にしたサイト
- [railsでFont Awesomeを使用するまでの手順](https://mebee.info/2020/08/26/post-15221/)
- [Link_toに画像やFontawesomeを使う方法](http://check.hatenadiary.com/entry/2017/08/29/190153)
