### PR TITLE
一覧表示画面のスタイル調整

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -5,8 +5,12 @@ class DocumentsController < ApplicationController
 
   def index
     @user_directories = UserDirectory.arrange
-    @documents = current_user.have_documents.limit(7)
-    @document = @documents.where(user_directory_id: params[:directory_id])
+    if params[:directory_id]
+      target_directory = current_user.user_directories.find(params[:directory_id])
+      target_directory_ids = target_directory.descendant_ids.push(target_directory.id)
+    end
+    # HACK: 分かりやすいコードに改善余地あり
+    @documents = target_directory_ids ? Document.where(user_directory: target_directory_ids) : Document.all
   end
 
   def show

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -6,7 +6,7 @@ class DocumentsController < ApplicationController
   def index
     @user_directories = UserDirectory.arrange
     @documents = current_user.have_documents.limit(7)
-    @document = @documents.page(params[:page])
+    @document = @documents.where(user_directory_id: params[:directory_id])
   end
 
   def show

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -1,3 +1,17 @@
-<% documents.each do |document| %>
-  <%= document.title %>
+<div class="container mt-4 pb-2 border-bottom">
+  <%= @documents[0].user_directory.name %>
+</div>
+
+<% @documents.each do |document| %>
+<div class="container">
+  <div class="row  border-bottom mt-2 pt-1 pb-0">
+    <div class="col-8 pl-4 mt-4">
+      <p><%= link_to document.title, document %></p>
+    </div>
+
+    <div class="col-4 text-center mt-4">
+      <div class>作成者:<%= document.writer.name %>　更新日:<%= document.updated_at.strftime('%Y年%m月%d日') %></div>
+    </div>
+  </div>
+</div>
 <% end %>

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -1,17 +1,17 @@
 <div class="container mt-4 pb-2 border-bottom">
-  <%= @documents[0].user_directory.name %>
+  <%= @document[0].user_directory.name %>
 </div>
 
-<% @documents.each do |document| %>
-<div class="container px-0">
-  <div class="row  border-bottom mt-2 pt-1 pb-0">
-    <div class="col-8 pl-4 mt-4">
-      <p><%= link_to document.title, document %></p>
-    </div>
+<% @document.each do |document| %>
+  <div class="container px-0">
+    <div class="row  border-bottom mt-2 pt-1 pb-0">
+      <div class="col-8 pl-4 mt-4">
+        <p><%= link_to document.title, document %></p>
+      </div>
 
-    <div class="col-4 text-center mt-4 px-0">
-      <div class>作成者:<%= document.writer.name %>　更新日:<%= document.updated_at.strftime('%Y年%m月%d日') %></div>
+      <div class="col-4 text-center mt-4 px-0">
+        <div class>作成者:<%= document.writer.name %>　更新日:<%= document.updated_at.strftime('%Y年%m月%d日') %></div>
+      </div>
     </div>
   </div>
-</div>
 <% end %>

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -3,13 +3,13 @@
 </div>
 
 <% @documents.each do |document| %>
-<div class="container">
+<div class="container px-0">
   <div class="row  border-bottom mt-2 pt-1 pb-0">
     <div class="col-8 pl-4 mt-4">
       <p><%= link_to document.title, document %></p>
     </div>
 
-    <div class="col-4 text-center mt-4">
+    <div class="col-4 text-center mt-4 px-0">
       <div class>作成者:<%= document.writer.name %>　更新日:<%= document.updated_at.strftime('%Y年%m月%d日') %></div>
     </div>
   </div>

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -1,8 +1,9 @@
 <div class="container mt-4 pb-2 border-bottom">
-  <%= @document[0].user_directory.name %>
+  <%= @documents[0].user_directory.name %>
+
 </div>
 
-<% @document.each do |document| %>
+<% @documents.each do |document| %>
   <div class="container px-0">
     <div class="row  border-bottom mt-2 pt-1 pb-0">
       <div class="col-8 pl-4 mt-4">

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -1,6 +1,5 @@
 <div class="container mt-4 pb-2 border-bottom">
   <%= @documents[0].user_directory.name %>
-
 </div>
 
 <% @documents.each do |document| %>
@@ -9,7 +8,6 @@
       <div class="col-8 pl-4 mt-4">
         <p><%= link_to document.title, document %></p>
       </div>
-
       <div class="col-4 text-center mt-4 px-0">
         <div class>作成者:<%= document.writer.name %>　更新日:<%= document.updated_at.strftime('%Y年%m月%d日') %></div>
       </div>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -1,6 +1,6 @@
 <%= javascript_pack_tag 'documents/index' %>
 
-<div class="row">
+<div class="row h-100">
   <div class="col-3 pr-0">
     <%= render partial: "layouts/sidebar", locals: { user_directories: @user_directories } %>
   </div>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -1,12 +1,10 @@
 <%= javascript_pack_tag 'documents/index' %>
 
-<div class="container">
-  <div class="row">
-    <div class="col-4">
-      <%= render partial: "layouts/sidebar", locals: { user_directories: @user_directories } %>
-    </div>
-    <div class="col-6">
-      <div id="directory_document"></div>
-    </div>
+<div class="row">
+  <div class="col-3 pr-0">
+    <%= render partial: "layouts/sidebar", locals: { user_directories: @user_directories } %>
+  </div>
+  <div class="col-9 px-5">
+    <div id="directory_document"></div>
   </div>
 </div>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -10,21 +10,3 @@
     </div>
   </div>
 </div>
-
-<div class="container mt-4 pb-2 border-bottom">
-  <%= @documents[0].user_directory.name %>
-</div>
-
-<% @documents.each do |document| %>
-<div class="container">
-  <div class="row  border-bottom mt-2 pt-1 pb-0">
-    <div class="col-8 pl-4 mt-4">
-      <p><%= link_to document.title, document %></p>
-    </div>
-
-    <div class="col-4 text-center mt-4">
-      <div class>作成者:<%= document.writer.name %>　更新日:<%= document.updated_at.strftime('%Y年%m月%d日') %></div>
-    </div>
-  </div>
-</div>
-<% end %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -2,27 +2,27 @@
 <ul class="directory h-100">
   <li class="item">
     <% user_directories.each do |first_directory, second_directories| %>
-      <%= link_to first_directory.name, documents_path, class: "link_color item__link js-directory__item__link border-bottom border-dark", remote: true %>
+      <%= link_to first_directory.name, documents_path(directory_id: first_directory.id), class: "link_color item__link js-directory__item__link border-bottom border-dark", remote: true %>
         <%# 2階層目 %>
         <ul class="directory_children area">
           <% second_directories.each do |second_directory, third_directories| %>
             <li class="item">
-              <%= link_to second_directory.name, documents_path, class: "link_color item__link js-directory__item__link border-bottom border-dark", remote: true %>
+              <%= link_to second_directory.name, documents_path(directory_id: second_directory.id), class: "link_color item__link js-directory__item__link border-bottom border-dark", remote: true %>
                 <%# 3階層目 %>
                 <ul class="directory_grand_children area">
                   <% third_directories.each do |third_directory, fourth_directories| %>
                     <li class="item">
-                      <%= link_to third_directory.name, documents_path, class: "link_color item__link js-directory__item__link border-bottom border-dark", remote: true %>
+                      <%= link_to third_directory.name, documents_path(directory_id: third_directory.id), class: "link_color item__link js-directory__item__link border-bottom border-dark", remote: true %>
                         <%# 4階層目 %>
                         <ul class="directory_great_grandson area">
                           <% fourth_directories.each do |fourth_directory, fifth_directories| %>
                             <li class="item">
-                              <%= link_to fourth_directory.name, documents_path, class: "link_color item__link js-directory__item__link border-bottom border-dark", remote: true %>
+                              <%= link_to fourth_directory.name, documents_path(directory_id: fourth_directory.id), class: "link_color item__link js-directory__item__link border-bottom border-dark", remote: true %>
                                 <%# 5階層目 %>
                                 <ul class="directory_great_great_grandson area">
                                   <% fifth_directories.each do |fifth_directory, _| %>
                                     <li class="item">
-                                      <%= link_to fifth_directory.name, documents_path, class: "link_color item__link js-directory__item__link border-bottom border-dark", remote: true %>
+                                      <%= link_to fifth_directory.name, documents_path(directory_id: fifth_directory.id), class: "link_color item__link js-directory__item__link border-bottom border-dark", remote: true %>
                                     </li>
                                   <% end %>
                                 </ul>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -1,5 +1,5 @@
 <%# 1階層 %>
-<ul class="directory">
+<ul class="directory h-100">
   <li class="item">
     <% user_directories.each do |first_directory, second_directories| %>
       <%= link_to first_directory.name, documents_path, class: "link_color item__link js-directory__item__link border-bottom border-dark", remote: true %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -2,27 +2,27 @@
 <ul class="directory">
   <li class="item">
     <% user_directories.each do |first_directory, second_directories| %>
-      <%= link_to first_directory.name, documents_path, class: "link_color item__link js-directory__item__link", remote: true %>
+      <%= link_to first_directory.name, documents_path, class: "link_color item__link js-directory__item__link border-bottom border-dark", remote: true %>
         <%# 2階層目 %>
         <ul class="directory_children area">
           <% second_directories.each do |second_directory, third_directories| %>
             <li class="item">
-              <%= link_to second_directory.name, documents_path, class: "link_color item__link js-directory__item__link", remote: true %>
+              <%= link_to second_directory.name, documents_path, class: "link_color item__link js-directory__item__link border-bottom border-dark", remote: true %>
                 <%# 3階層目 %>
                 <ul class="directory_grand_children area">
                   <% third_directories.each do |third_directory, fourth_directories| %>
                     <li class="item">
-                      <%= link_to third_directory.name, documents_path, class: "link_color item__link js-directory__item__link", remote: true %>
+                      <%= link_to third_directory.name, documents_path, class: "link_color item__link js-directory__item__link border-bottom border-dark", remote: true %>
                         <%# 4階層目 %>
                         <ul class="directory_great_grandson area">
                           <% fourth_directories.each do |fourth_directory, fifth_directories| %>
                             <li class="item">
-                              <%= link_to fourth_directory.name, documents_path, class: "link_color item__link js-directory__item__link", remote: true %>
+                              <%= link_to fourth_directory.name, documents_path, class: "link_color item__link js-directory__item__link border-bottom border-dark", remote: true %>
                                 <%# 5階層目 %>
                                 <ul class="directory_great_great_grandson area">
                                   <% fifth_directories.each do |fifth_directory, _| %>
                                     <li class="item">
-                                      <%= link_to fifth_directory.name, documents_path, class: "link_color item__link js-directory__item__link", remote: true %>
+                                      <%= link_to fifth_directory.name, documents_path, class: "link_color item__link js-directory__item__link border-bottom border-dark", remote: true %>
                                     </li>
                                   <% end %>
                                 </ul>


### PR DESCRIPTION
## 概要
- ドキュメント一覧表示画面のデザインを調整


## タスク内容
- `index.html.erb`のドキュメント一覧表示のコードを`_document.html.erb`ファイルに移す
- ディレクトリのlink_toにパラメータを付与して、クリックした際に表示するドキュメントを指定
- 一覧画面のデザインを調整
- 一番上のディレクトリをクリックした際に子ディレクトリ以下のドキュメントを表示できるように設定
## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub の Files changed で差分を確認
- [x] 影響し得る範囲のローカル環境での動作確認


## 実装画面
![ディレクトリ以下のドキュメント表示](https://user-images.githubusercontent.com/67620156/117559431-28d21c80-b0c0-11eb-96de-072fca9425aa.gif)



## その他参考情報


### その他
- リファクタリングの余地あり
- ディレクトリ選択してない状態でドキュメント全て表示するところはできてないです。
