### PR TITLE
記事作成ページのタイトル入力と同時に、ディレクトリを作成 or 参照するように設定を変更

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -16,13 +16,47 @@ class DocumentsController < ApplicationController
 
   def create
     # TODO: モック部、Devise実装後に修正必要
-    user_directory = current_user.user_directories.first
-    add_params = { owner: current_user, user_directory: user_directory }
-    @document = current_user.documents.create!(document_params.merge(add_params))
+    title_with_directory = params[:document][:title_with_directory].split("/")
+    title = title_with_directory[-1]
+    case title_with_directory.length
+    when 1
+      if current_user.user_directories.exists?(name: "no category")
+        add_params = { title: title, owner: current_user, user_directory: current_user.user_directories.find_by(name: "no category") }
+        @document = current_user.documents.create!(document_params.merge(add_params))
+      else
+        current_user.user_directories.create!(name: "no category")
+        add_params = { title: title, owner: current_user, user_directory: current_user.user_directories.find_by(name: "no category") }
+        @document = current_user.documents.create!(document_params.merge(add_params))
+      end
+    when 2
+      parents_directory = title_with_directory[0]
+      if current_user.user_directories.exists?(name: parents_directory)
+        add_params = { title: title, owner: current_user, user_directory: current_user.user_directories.find_by(name: parents_directory) }
+        @document = current_user.documents.create!(document_params.merge(add_params))
+      else
+        current_user.user_directories.create!(name: parents_directory)
+        add_params = { title: title, owner: current_user, user_directory: current_user.user_directories.find_by(name: parents_directory) }
+        @document = current_user.documents.create!(document_params.merge(add_params))
+      end
+    when 3
+      parents_directory = title_with_directory[0]
+      children_directory = title_with_directory[1]
+      if current_user.user_directories.exists?(name: parents_directory)
+        add_params = { title: title, owner: current_user, user_directory: current_user.user_directories.find_by(name: children_directory) }
+        @document = current_user.documents.create!(document_params.merge(add_params))
+      else
+        current_user.user_directories.create!(name: parents_directory)
+      end
+
+
+
+
+
+    end
     redirect_to @document, notice: "ドキュメントを登録しました。"
   end
 
   def document_params
-    params.require(:document).permit(:title, :body)
+    params.require(:document).permit(:title_with_directory, :body)
   end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -15,21 +15,21 @@ class DocumentsController < ApplicationController
   end
 
   def create # rubocop:disable Metrics/AbcSize
-    # タイトルの文字列を / 毎に配列に直す
+    # Description: タイトルの文字列を / 毎に配列に直す
     directories_and_title = params[:document][:title_with_directory].split("/")
-    # タイトル名は配列の一番後ろなので pop で取り出す
+    # Description: タイトル名は配列の一番後ろなので pop で取り出す
     title = directories_and_title.pop
     ActiveRecord::Base.transaction do
-      # タイトル記入欄にタイトルのみしか記載されていない場合は"指定なし" そうでない場合は一番親のディレクトリ名を取り出す
+      # Description: タイトル記入欄にタイトルのみしか記載されていない場合は"指定なし" そうでない場合は一番親のディレクトリ名を取り出す
       first_directory_name = directories_and_title.blank? ? "指定なし" : directories_and_title[0]
-      # 取り出したディレクトリ名で prev_directory という変数名でディレクトリを保存、既に同じ名前のディレクトリがある場合はそのディレクトリを参照
+      # Description: 取り出したディレクトリ名で prev_directory という変数名でディレクトリを保存、既に同じ名前のディレクトリがある場合はそのディレクトリを参照
       prev_directory = current_user.user_directories.find_or_create_by!(name: first_directory_name, ancestry: nil)
-      # 最初に定義した directories_and_title は pop でタイトルだけ取り出されているため、残ったディレクトリを each で親から順番に回す
+      # Description: 最初に定義した directories_and_title は pop でタイトルだけ取り出されているため、残ったディレクトリを each で親から順番に回す
       directories_and_title.each_with_index do |directory_name, i|
-        # 一番親のディレクトリは prev_directory で定義済みのため、スルー
+        # Description: 一番親のディレクトリは prev_directory で定義済みのため、スルー
         next if i == 0
 
-        # prev_directory の子ディレクトリを each で取り出したディレクトリ名でオーバーライドし保存 or 参照(find_or_create_by)を繰り返す
+        # Description: prev_directory の子ディレクトリを each で取り出したディレクトリ名でオーバーライドし保存 or 参照(find_or_create_by)を繰り返す
         prev_directory = prev_directory.children.find_or_create_by!(name: directory_name, user: current_user)
       end
       add_params = { title: title, owner: current_user, user_directory: prev_directory }

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -14,7 +14,7 @@ class DocumentsController < ApplicationController
     @directory = @document.user_directory.path.pluck(:name)
   end
 
-  def create
+  def create # rubocop:disable Metrics/AbcSize
     directories_and_title = params[:document][:title_with_directory].split("/")
     title = directories_and_title.pop
     ActiveRecord::Base.transaction do

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -15,14 +15,21 @@ class DocumentsController < ApplicationController
   end
 
   def create # rubocop:disable Metrics/AbcSize
+    # タイトルの文字列を / 毎に配列に直す
     directories_and_title = params[:document][:title_with_directory].split("/")
+    # タイトル名は配列の一番後ろなので pop で取り出す
     title = directories_and_title.pop
     ActiveRecord::Base.transaction do
+      # タイトル記入欄にタイトルのみしか記載されていない場合は"指定なし" そうでない場合は一番親のディレクトリ名を取り出す
       first_directory_name = directories_and_title.blank? ? "指定なし" : directories_and_title[0]
+      # 取り出したディレクトリ名で prev_directory という変数名でディレクトリを保存、既に同じ名前のディレクトリがある場合はそのディレクトリを参照
       prev_directory = current_user.user_directories.find_or_create_by!(name: first_directory_name, ancestry: nil)
+      # 最初に定義した directories_and_title は pop でタイトルだけ取り出されているため、残ったディレクトリを each で親から順番に回す
       directories_and_title.each_with_index do |directory_name, i|
+        # 一番親のディレクトリは prev_directory で定義済みのため、スルー
         next if i == 0
 
+        # prev_directory の子ディレクトリを each で取り出したディレクトリ名でオーバーライドし保存 or 参照(find_or_create_by)を繰り返す
         prev_directory = prev_directory.children.find_or_create_by!(name: directory_name, user: current_user)
       end
       add_params = { title: title, owner: current_user, user_directory: prev_directory }

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -33,4 +33,5 @@ class Document < ApplicationRecord
   belongs_to :owner, polymorphic: true
 
   validates :title, length: { maximum: 50 }, presence: true
+  attr_accessor :title_with_directory
 end

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -11,7 +11,7 @@
     <div class="col-12">
       <div class='form-group mt-3 pr-3'>
         <%= f.label :タイトル %>
-        <%= f.text_field :title, class: 'form-control', placeholder: 'タイトル' %>
+        <%= f.text_field :title_with_directory, class: 'form-control', placeholder: 'タイトル' %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 概要
- 記事作成ページのタイトル入力と同時に、ディレクトリを作成 or 参照するように設定を変更

## タスク内容
- view から送信する値をtitle_with_directory に変更
- `attr` をモデルに定義することで title_with_directory を送信できるように設定を変更
- documents_controller の create メソッド内の処理を変更

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub の Files changed で差分を確認
- [x] 影響し得る範囲のローカル環境での動作確認


## 実装画面
- スクリーンショットなどを貼り付け
![スクリーンショット 2021-05-08 23 39 49](https://user-images.githubusercontent.com/77535025/117543212-cb55b580-b056-11eb-86d8-3c8df2198582.png)
![スクリーンショット 2021-05-08 23 40 04](https://user-images.githubusercontent.com/77535025/117543216-cf81d300-b056-11eb-90bf-6ec30577c543.png)

