### PR TITLE
ディレクトリが６つ以上作成できないようにバリデーションを設定

### DIFF
--- a/app/models/user_directory.rb
+++ b/app/models/user_directory.rb
@@ -24,4 +24,5 @@ class UserDirectory < ApplicationRecord
   has_ancestry
 
   validates :name, length: { maximum: 20 }, presence: true
+  validates :ancestry, ancestry: true, allow_nil: true
 end

--- a/app/validators/ancestry_validator.rb
+++ b/app/validators/ancestry_validator.rb
@@ -1,0 +1,7 @@
+class AncestryValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if value.count("/") > 3
+      record.errors.add("ディレクトリは6つ以上作成できません！")
+    end
+  end
+end

--- a/app/validators/ancestry_validator.rb
+++ b/app/validators/ancestry_validator.rb
@@ -1,5 +1,6 @@
 class AncestryValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
+    # HACK: /で判断させるのは直感的ではないため別の方法も検討する
     if value.count("/") > 3
       record.errors.add("ディレクトリは6つ以上作成できません！")
     end

--- a/spec/models/user_directory_spec.rb
+++ b/spec/models/user_directory_spec.rb
@@ -55,16 +55,19 @@ RSpec.describe UserDirectory, type: :model do
       end
     end
   end
+
+  # rubocop:disable RSpec/MultipleMemoizedHelpers
   describe "カスタムバリデーションのチェック" do
     let(:first_user_directory) { create(:user_directory) }
     let(:second_user_directory) { first_user_directory.children.create(name: "1", user: first_user_directory.user) }
     let(:third_user_directory) { second_user_directory.children.create(name: "2", user: second_user_directory.user) }
     let(:forth_user_directory) { third_user_directory.children.create(name: "3", user: third_user_directory.user) }
-    let(:fifth_user_directory) { forth_user_directory.children.create(name: "4", user: forth_user_directory.user)  }
-    let(:six_user_directory) { fifth_user_directory.children.create(name: "5", user: fifth_user_directory.user)  }
+    let(:fifth_user_directory) { forth_user_directory.children.create(name: "4", user: forth_user_directory.user) }
+    let(:six_user_directory) { fifth_user_directory.children.create(name: "5", user: fifth_user_directory.user) }
 
     context "ディレクトリの階層が５階層までのとき" do
       subject { fifth_user_directory }
+
       it "ユーザーディレクトリが作られる" do
         expect(subject).to be_valid
       end
@@ -72,9 +75,11 @@ RSpec.describe UserDirectory, type: :model do
 
     context "ディレクトリの階層が６階層以上のとき" do
       subject { six_user_directory }
+
       it "ユーザーディレクトリは作られない" do
         expect(subject).not_to be_valid
       end
     end
   end
+  # rubocop:enable RSpec/MultipleMemoizedHelpers
 end

--- a/spec/models/user_directory_spec.rb
+++ b/spec/models/user_directory_spec.rb
@@ -55,4 +55,26 @@ RSpec.describe UserDirectory, type: :model do
       end
     end
   end
+  describe "カスタムバリデーションのチェック" do
+    let(:first_user_directory) { create(:user_directory) }
+    let(:second_user_directory) { first_user_directory.children.create(name: "1", user: first_user_directory.user) }
+    let(:third_user_directory) { second_user_directory.children.create(name: "2", user: second_user_directory.user) }
+    let(:forth_user_directory) { third_user_directory.children.create(name: "3", user: third_user_directory.user) }
+    let(:fifth_user_directory) { forth_user_directory.children.create(name: "4", user: forth_user_directory.user)  }
+    let(:six_user_directory) { fifth_user_directory.children.create(name: "5", user: fifth_user_directory.user)  }
+
+    context "ディレクトリの階層が５階層までのとき" do
+      subject { fifth_user_directory }
+      it "ユーザーディレクトリが作られる" do
+        expect(subject).to be_valid
+      end
+    end
+
+    context "ディレクトリの階層が６階層以上のとき" do
+      subject { six_user_directory }
+      it "ユーザーディレクトリは作られない" do
+        expect(subject).not_to be_valid
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
- ユーザーディレクトリ作成時に６階層目できないようにバリデーションを追加


## タスク内容
- `app/validators/ancestry_validator.rb`ファイルを作成
  - ancestryカラムの値`/`の数で階層をチェックするバリデーションを設定
- `app/models/user_directory.rb`にカスタムバリデーションを追加
  - 親ディレクトリの時はバリデーションをスルーできるように`allow_nil: true`を追記

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub の Files changed で差分を確認
- [x] 影響し得る範囲のローカル環境での動作確認
