### PR TITLE
本番環境でエラー時にSlackにエラー内容を通知するように設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,9 +15,9 @@ gem "puma", "~> 5.0"
 gem "rails", "~> 6.1.3"
 gem "rails-i18n", "~> 6.0"
 gem "sass-rails", ">= 6"
+gem "slack-notifier"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0"
-gem "slack-notifier"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "rails-i18n", "~> 6.0"
 gem "sass-rails", ">= 6"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0"
+gem "slack-notifier"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,6 +263,7 @@ GEM
       sprockets-rails
       tilt
     semantic_range (3.0.0)
+    slack-notifier (2.4.0)
     spring (2.1.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -325,6 +326,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   sass-rails (>= 6)
+  slack-notifier
   spring
   turbolinks (~> 5)
   tzinfo-data

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include ErrorHandler
+
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!
 

--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -5,7 +5,7 @@ module ErrorHandler
 
   included do
     if Rails.env.production?
-      rescue_from Exception, with: :render_500
+      rescue_from Exception, with: :render500
       rescue_from ::ActiveRecord::RecordNotFound, with: :redirect_root
     end
   end
@@ -14,9 +14,9 @@ module ErrorHandler
     redirect_to root_url
   end
 
-  def render_500(e)
+  def render500(e)
     send_error_message(e)
-    render file: "#{Rails.root}/public/500.html", layout: false, status: 500
+    render file: "#{Rails.root}/public/500.html", layout: false, status: :internal_server_error
   end
 
   private
@@ -28,7 +28,7 @@ module ErrorHandler
         *Error Point:* #{e.backtrace.first}
       TEXT
 
-      webhook_url = ENV['SLACK_WEBHOOK_URL']
+      webhook_url = ENV["SLACK_WEBHOOK_URL"]
       notifier = Slack::Notifier.new(webhook_url)
       notifier.ping(message)
     end

--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -1,0 +1,35 @@
+require "slack-notifier"
+
+module ErrorHandler
+  extend ActiveSupport::Concern
+
+  included do
+    if Rails.env.production?
+      rescue_from Exception, with: :render_500
+      rescue_from ::ActiveRecord::RecordNotFound, with: :redirect_root
+    end
+  end
+
+  def redirect_root
+    redirect_to root_url
+  end
+
+  def render_500(e)
+    send_error_message(e)
+    render file: "#{Rails.root}/public/500.html", layout: false, status: 500
+  end
+
+  private
+
+    def send_error_message(e)
+      message = <<~TEXT
+        *【#{Rails.env}】 予期せぬエラーが発生しました*
+        *Error:* #{e.inspect}
+        *Error Point:* #{e.backtrace.first}
+      TEXT
+
+      webhook_url = ENV['SLACK_WEBHOOK_URL']
+      notifier = Slack::Notifier.new(webhook_url)
+      notifier.ping(message)
+    end
+end


### PR DESCRIPTION
## 概要
- 本番環境でエラー時にSlackにエラー内容を通知するように設定


## タスク内容
- slack-notifierのGemをインストール
- ErrorHandlerの作成

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub の Files changed で差分を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

### その他
- `SLACK_WEBHOOK_URL` 環境変数にSlackのWebhookのURLを記載する
