### PR TITLE
ドキュメントを所持していないユーザーもドキュメント一覧画面へアクセスできるように設定

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -11,6 +11,7 @@ class DocumentsController < ApplicationController
     end
     # HACK: 分かりやすいコードに改善余地あり
     @documents = target_directory_ids ? Document.where(user_directory: target_directory_ids) : current_user.have_documents
+    @document = @documents.first
   end
 
   def show

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -11,7 +11,7 @@ class DocumentsController < ApplicationController
     end
     # HACK: 分かりやすいコードに改善余地あり
     @documents = target_directory_ids ? Document.where(user_directory: target_directory_ids) : current_user.have_documents
-    @document = @documents.first
+    @current_directory_name = target_directory&.name || "ドキュメント一覧"
   end
 
   def show

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -1,5 +1,5 @@
 <div class="container mt-4 pb-2 border-bottom">
-  <%= @documents[0]&.user_directory&.name %>
+  <%= @document&.user_directory&.name %>
 </div>
 
 <% @documents.each do |document| %>

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -1,5 +1,5 @@
 <div class="container mt-4 pb-2 border-bottom">
-  <%= @documents[0].user_directory.name %>
+  <%= @documents[0]&.user_directory&.name %>
 </div>
 
 <% @documents.each do |document| %>

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -1,5 +1,5 @@
 <div class="container mt-4 pb-2 border-bottom">
-  <%= @document&.user_directory&.name %>
+  <%= @current_directory_name %>
 </div>
 
 <% @documents.each do |document| %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -5,10 +5,8 @@
     <%= render partial: "layouts/sidebar", locals: { user_directories: @user_directories } %>
   </div>
   <div class="col-9 px-5">
-    <% if @documents.present? %>
-      <div id="directory_document">
-        <%= render partial: 'document', locals: { documents: @documents } %>
-      </div>
-    <% end %>
+    <div id="directory_document">
+      <%= render partial: 'document', locals: { documents: @documents } %>
+    </div>
   </div>
 </div>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -5,8 +5,10 @@
     <%= render partial: "layouts/sidebar", locals: { user_directories: @user_directories } %>
   </div>
   <div class="col-9 px-5">
-    <div id="directory_document">
-      <%= render partial: 'document', locals: { documents: @documents } %>
-    </div>
+    <% if @documents.present? %>
+      <div id="directory_document">
+        <%= render partial: 'document', locals: { documents: @documents } %>
+      </div>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
## 概要
- 新規ユーザーがアクセスした際にエラーが出ないように調整


## タスク内容
- ドキュメントを持っているかでドキュメント一覧部分を表示するか判定させる

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub の Files changed で差分を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
