### PR TITLE
ドキュメント削除機能の実装とディレクトリ削除機能をドキュメント編集機能に追加

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -67,7 +67,7 @@ class DocumentsController < ApplicationController
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
-  def update # rubocop:disable Metrics/AbcSize
+  def update # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     directories_and_title = params[:document][:title].split("/")
     title = directories_and_title.pop
     body = params[:document][:body]
@@ -89,7 +89,7 @@ class DocumentsController < ApplicationController
       @document.update!(document_elements)
       past_directories.each do |directory|
         if directory.documents.blank? &&
-          directory.is_childless?
+           directory.is_childless?
           directory.destroy!
         else
           break
@@ -105,7 +105,7 @@ class DocumentsController < ApplicationController
     @document.destroy!
     past_directories.each do |directory|
       if directory.documents.blank? &&
-        directory.is_childless?
+         directory.is_childless?
         directory.destroy!
       else
         break

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -87,25 +87,26 @@ class DocumentsController < ApplicationController
         user_directory: prev_directory,
       }
       @document.update!(document_elements)
-      past_directories.each do |directory|
-        if directory.documents.blank? &&
-           directory.is_childless?
-          directory.destroy!
-        else
-          break
-        end
-      end
+      sort_directories(past_directories)
     end
     redirect_to @document, notice: "ドキュメントを更新しました。"
   end
 
   def destroy
     @document = current_user.have_documents.find(params[:id])
-    @past_directories = @document.user_directory.path.reverse_order
+    past_directories = @document.user_directory.path.reverse_order
     ActiveRecord::Base.transaction do
       @document.destroy!
-      @past_directories.delete_directories
+      sort_directories(past_directories)
     end
     redirect_to root_path, notice: "ドキュメントを削除しました"
   end
+
+  private
+
+    def sort_directories(target_directories)
+      target_directories.each do |directory|
+        directory.do_not_have? ? directory.destroy! : break
+      end
+    end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -87,7 +87,7 @@ class DocumentsController < ApplicationController
         user_directory: prev_directory,
       }
       @document.update!(document_elements)
-      sort_directories(past_directories)
+      destroy_no_content_directories(past_directories)
     end
     redirect_to @document, notice: "ドキュメントを更新しました。"
   end
@@ -97,14 +97,14 @@ class DocumentsController < ApplicationController
     past_directories = @document.user_directory.path.reverse_order
     ActiveRecord::Base.transaction do
       @document.destroy!
-      sort_directories(past_directories)
+      destroy_no_content_directories(past_directories)
     end
     redirect_to root_path, notice: "ドキュメントを削除しました"
   end
 
   private
 
-    def sort_directories(target_directories)
+    def destroy_no_content_directories(target_directories)
       target_directories.each do |directory|
         directory.do_not_have? ? directory.destroy! : break
       end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -89,4 +89,19 @@ class DocumentsController < ApplicationController
     end
     redirect_to @document, notice: "ドキュメントを更新しました。"
   end
+
+  def destroy
+    @document = current_user.have_documents.find(params[:id])
+    past_directories = @document.user_directory.path.reverse_order
+    @document.destroy!
+    past_directories.each do |directory|
+      if directory.documents.blank? &&
+        directory.is_childless?
+        directory.destroy!
+      else
+        break
+      end
+    end
+    redirect_to root_path, notice: "ドキュメントを削除しました"
+  end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -101,15 +101,10 @@ class DocumentsController < ApplicationController
 
   def destroy
     @document = current_user.have_documents.find(params[:id])
-    past_directories = @document.user_directory.path.reverse_order
-    @document.destroy!
-    past_directories.each do |directory|
-      if directory.documents.blank? &&
-         directory.is_childless?
-        directory.destroy!
-      else
-        break
-      end
+    @past_directories = @document.user_directory.path.reverse_order
+    ActiveRecord::Base.transaction do
+      @document.destroy!
+      @past_directories.delete_directories
     end
     redirect_to root_path, notice: "ドキュメントを削除しました"
   end

--- a/app/models/user_directory.rb
+++ b/app/models/user_directory.rb
@@ -25,4 +25,15 @@ class UserDirectory < ApplicationRecord
 
   validates :name, length: { maximum: 20 }, presence: true
   validates :ancestry, ancestry: true, allow_nil: true
+
+
+  def self.delete_directories
+    each do |directory|
+      if directory.documents.blank? && directory.is_childless?
+       directory.destroy!
+     else
+       break
+     end
+    end
+  end
 end

--- a/app/models/user_directory.rb
+++ b/app/models/user_directory.rb
@@ -26,14 +26,7 @@ class UserDirectory < ApplicationRecord
   validates :name, length: { maximum: 20 }, presence: true
   validates :ancestry, ancestry: true, allow_nil: true
 
-
-  def self.delete_directories
-    each do |directory|
-      if directory.documents.blank? && directory.is_childless?
-       directory.destroy!
-     else
-       break
-     end
-    end
+  def do_not_have?
+    self.documents.blank? && self.is_childless?
   end
 end

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -8,6 +8,9 @@
     <div class="col-8 pl-4 mt-4">
       <span><%= link_to document.title, document %></span>
       <span>
+        <%= link_to edit_document_path(document), class: "text-decoration-none" do %>
+        <i class="fas fa-pen ml-2"></i>
+        <% end %>
         <%= link_to document_path(document), method: :delete do %>
         <i class="fas fa-trash-alt ml-2"></i>
         <% end %>

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -3,14 +3,19 @@
 </div>
 
 <% @documents.each do |document| %>
-  <div class="container px-0">
-    <div class="row  border-bottom mt-2 pt-1 pb-0">
-      <div class="col-8 pl-4 mt-4">
-        <p><%= link_to document.title, document %></p>
-      </div>
-      <div class="col-4 text-center mt-4 px-0">
-        <div class>作成者:<%= document.writer.name %>　更新日:<%= document.updated_at.strftime('%Y年%m月%d日') %></div>
-      </div>
+<div class="container px-0">
+  <div class="row  border-bottom mt-2 pt-1 pb-0">
+    <div class="col-8 pl-4 mt-4">
+      <span><%= link_to document.title, document %></span>
+      <span>
+        <%= link_to document_path(document), method: :delete do %>
+        <i class="fas fa-trash-alt ml-2"></i>
+        <% end %>
+      </span>
+    </div>
+    <div class="col-4 text-center mt-4 px-0">
+      <div class>作成者:<%= document.writer.name %>　更新日:<%= document.updated_at.strftime('%Y年%m月%d日') %></div>
     </div>
   </div>
+</div>
 <% end %>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -8,7 +8,7 @@
         <%= @document.title %>
       </h1>
       <%= link_to edit_document_path, class: "text-decoration-none" do %>
-      <i class="fas fa-pen-nib fa-2x pb-1 ml-2"></i>
+      <i class="fas fa-pen fa-2x pb-1 ml-2"></i>
       <% end %>
       <%= link_to document_path(@document), method: :delete do %>
       <i class="fas fa-trash-alt fa-2x pb-1 ml-2"></i>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -8,7 +8,10 @@
         <%= @document.title %>
       </h1>
       <%= link_to edit_document_path, class: "text-decoration-none" do %>
-      <i class="fas fa-pen-nib fa-2x pb-1 ml-2"></i><br>
+      <i class="fas fa-pen-nib fa-2x pb-1 ml-2"></i>
+      <% end %>
+      <%= link_to document_path(@document), method: :delete do %>
+      <i class="fas fa-trash-alt fa-2x pb-1 ml-2"></i>
       <% end %>
     </div>
     <div class="col col-4 text-center">


### PR DESCRIPTION
## 概要
- 表題の通り

## タスク内容
- documents_controller の destroy メソッドの実装
- ドキュメント一覧ページとドキュメント詳細ページにドキュメント削除ボタンを実装
- ドキュメント一覧ページに追加し忘れたドキュメント編集ボタンを実装
- ドキュメント編集ボタンのアイコンを変更
- documents_controller の update メソッド内に ディレクトリ削除機能を追加

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub の Files changed で差分を確認
- [ ] 影響し得る範囲のローカル環境での動作確認


## 実装画面
![スクリーンショット 2021-05-12 1 23 59](https://user-images.githubusercontent.com/77535025/117850961-c98f2a80-b2c0-11eb-9b8e-8c306b626171.png)