### PR TITLE
ディレクトリサイドバーに自分のディレクトリのみ表示されるように変更

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -10,7 +10,7 @@ class DocumentsController < ApplicationController
   end
 
   def index
-    @user_directories = UserDirectory.arrange
+    @user_directories = current_user.user_directories.arrange
     if params[:directory_id]
       target_directory = current_user.user_directories.find(params[:directory_id])
       target_directory_ids = target_directory.descendant_ids.push(target_directory.id)


### PR DESCRIPTION
## 概要
- 表題の通り


## タスク内容
- 表題の通り

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub の Files changed で差分を確認
- [ ] 影響し得る範囲のローカル環境での動作確認


## 実装画面
 ユーザーを2名登録し、異なるユーザーが異なるディレクトリでドキュメント作成しましたが、ドキュメント一覧画面で下記スクリーンショットのようになったので、修正できたかと思います。
![スクリーンショット 2021-05-13 0 36 05](https://user-images.githubusercontent.com/77535025/118003410-85b12980-b383-11eb-93d2-faa2bde86954.png)
