### PR TITLE
ドキュメント作成画面のタイトルを表示させ、プレビュー画面の border から文字がはみ出るバグの修正

### DIFF
--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -64,9 +64,10 @@ ul {
 }
 
 .preview {
-  overflow: auto;
+  overflow-wrap: break-word;
+  overflow-y: auto;
   min-height: 390px;
-  height: calc(100vh - 365px)
+  height: calc(100vh - 340px)
 }
 
 pre {

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -64,8 +64,9 @@ ul {
 }
 
 .preview {
-  height: 95%;
-
+  overflow: auto;
+  min-height: 390px;
+  height: calc(100vh - 365px)
 }
 
 pre {

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -64,7 +64,7 @@ ul {
 }
 
 .preview {
-  height: calc(100% - 135px);
+  height: 95%;
 
 }
 

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -1,4 +1,10 @@
-
+<div class="container create_document_container">
+  <div class="row border-bottom mt-5">
+    <h2>
+      <i class="fas fa-pen-nib text-primary"></i>
+      ドキュメント作成
+    </h2>
+  </div>
   <%= form_with model:@document do |f| %>
   <div class="row">
     <div class="col-12">
@@ -18,7 +24,7 @@
         <%= f.label :画像を添付 %>
         <%= f.file_field :image, multiple: true %>
       </div>
-      <div class="text-right mb-5">
+      <div class="text-right">
         <%= f.submit '作成', class: 'btn btn-primary create_docuent_button' %>
         <% end %>
       </div>


### PR DESCRIPTION
## 概要
- 表題の通り

## タスク内容
- 表題の通り

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub の Files changed で差分を確認
- [ ] 影響し得る範囲のローカル環境での動作確認


## 実装画面
![スクリーンショット 2021-05-13 11 22 04](https://user-images.githubusercontent.com/77535025/118069182-aa86ba80-b3de-11eb-9739-4997a3ace7ce.png)
