### PR TITLE
サイドバーにログアウトボタン設置

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,10 @@
 module ApplicationHelper
+  def text_color
+    case controller.action_name
+    when "index"
+      "text-light"
+    else
+      "text-danger"
+    end
+  end
 end

--- a/app/javascript/packs/sidebar.js
+++ b/app/javascript/packs/sidebar.js
@@ -1,0 +1,6 @@
+const btn = document.querySelector('.btn-menu');
+const nav = document.querySelector('nav');
+
+btn.addEventListener('click', () => {
+  nav.classList.toggle('open-menu')
+});

--- a/app/javascript/packs/sidebar.js
+++ b/app/javascript/packs/sidebar.js
@@ -1,6 +1,3 @@
-const btn = document.querySelector('.btn-menu');
-const nav = document.querySelector('nav');
-
-btn.addEventListener('click', () => {
-  nav.classList.toggle('open-menu')
+$('.accordion-side').click(function () {
+  $(this).next().animate({ width: 'toggle' }, 'normal');
 });

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -107,22 +107,17 @@ p code, li code {
   width: calc(100% + 150px);
   position: absolute;
   bottom: 30px;
-
-  .row {
-    margin-right: 0;
-  }
 }
 
 .accordion-side {
-  width: 43%;
+  width: 35%;
   padding: 0;
 }
 
 .accordion-content-side {
   display: none;
   z-index: 1;
-  width: 57%;
+  width: 65%;
   white-space: nowrap;
   text-align: left;
-  margin-left: -10px;
 }

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -46,6 +46,7 @@ ul {
     font-size: 0.8rem;
     width: 80px;
     min-height: 100vh;
+    position: relative;
 
     .fa-pen-nib {
       font-size: 2.5rem;
@@ -104,6 +105,8 @@ p code, li code {
 
 .accordion-inner {
   width: calc(100% + 150px);
+  position: absolute;
+  bottom: 30px;
 
   .row {
     margin-right: 0;

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -102,15 +102,24 @@ p code, li code {
   border: 0;
 }
 
-nav {
-  overflow-x: hidden;
-  width: 0;
+.accordion-inner {
+  width: calc(100% + 150px);
+
+  .row {
+    margin-right: 0;
+  }
 }
 
-nav.open-menu {
-  width: 100%;
+.accordion-side {
+  width: 43%;
+  padding: 0;
 }
 
-.side-menu-item {
-  margin-top: 1rem;
+.accordion-content-side {
+  display: none;
+  z-index: 1;
+  width: 57%;
+  white-space: nowrap;
+  text-align: left;
+  margin-left: -10px;
 }

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -96,3 +96,21 @@ p code, li code {
 }
 
 @import 'highlight.js/styles/railscasts.css';
+
+// サイドメニュー
+.btn-menu {
+  border: 0;
+}
+
+nav {
+  overflow-x: hidden;
+  width: 0;
+}
+
+nav.open-menu {
+  width: 100%;
+}
+
+.side-menu-item {
+  margin-top: 1rem;
+}

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -30,5 +30,4 @@
     </div>
   </div>
 </div>
-<%= link_to 'ログアウト', destroy_user_session_path, method: :delete %>
 <%= javascript_pack_tag 'documents/show' %>

--- a/app/views/layouts/_documents_sidebar.html.erb
+++ b/app/views/layouts/_documents_sidebar.html.erb
@@ -13,7 +13,7 @@
   </div>
   <div class="accordion-inner">
     <div class="accordion-box-side row">
-      <button class="btn-menu bg-primary accordion-side" ><i class="fas fa-ellipsis-h fa-4x" style="color: white;" ></i></button>
+      <button class="btn-menu bg-primary accordion-side" ><i class="fas fa-ellipsis-h fa-4x pl-2" style="color: white;" ></i></button>
       <div class="accordion-content-side">
         <button type="botton" class="btn btn-outline-dark btn-lg">
           <%= link_to 'ログアウト', destroy_user_session_path, class: text_color, method: :delete %>

--- a/app/views/layouts/_documents_sidebar.html.erb
+++ b/app/views/layouts/_documents_sidebar.html.erb
@@ -11,13 +11,15 @@
     ドキュメント一覧<br>
     <% end %>
   </div>
-  <div class="pt-4">
-    <button class="btn-menu bg-primary" ><i class="fas fa-ellipsis-h fa-4x" style="color: white;" ></i></button>
-    <nav>
-      <ul class="pl-0">
-        <li class="side-menu-item"><%= link_to 'ログアウト', destroy_user_session_path, class:"text-white", method: :delete %></li>
-      </ul>
-    </nav>
+  <div class="accordion-inner">
+    <div class="accordion-box-side row">
+      <button class="btn-menu bg-primary accordion-side" ><i class="fas fa-ellipsis-h fa-4x" style="color: white;" ></i></button>
+      <div class="accordion-content-side">
+        <button type="botton" class="btn btn-outline-dark btn-lg">
+          <%= link_to 'ログアウト', destroy_user_session_path, class:"text-danger", method: :delete %>
+        </button>
+      </div>
+    </div>
   </div>
 </div>
 <%= javascript_pack_tag 'sidebar' %>

--- a/app/views/layouts/_documents_sidebar.html.erb
+++ b/app/views/layouts/_documents_sidebar.html.erb
@@ -15,7 +15,7 @@
     <button class="btn-menu bg-primary" ><i class="fas fa-ellipsis-h fa-4x" style="color: white;" ></i></button>
     <nav>
       <ul class="pl-0">
-        <li><%= link_to 'ログアウト', destroy_user_session_path, class:"text-white", method: :delete %></li>
+        <li class="side-menu-item"><%= link_to 'ログアウト', destroy_user_session_path, class:"text-white", method: :delete %></li>
       </ul>
     </nav>
   </div>

--- a/app/views/layouts/_documents_sidebar.html.erb
+++ b/app/views/layouts/_documents_sidebar.html.erb
@@ -11,4 +11,13 @@
     ドキュメント一覧<br>
     <% end %>
   </div>
+  <div class="pt-4">
+    <button class="btn-menu bg-primary" ><i class="fas fa-ellipsis-h fa-4x" style="color: white;" ></i></button>
+    <nav>
+      <ul class="pl-0">
+        <li><%= link_to 'ログアウト', destroy_user_session_path, class:"text-white", method: :delete %></li>
+      </ul>
+    </nav>
+  </div>
 </div>
+<%= javascript_pack_tag 'sidebar' %>

--- a/app/views/layouts/_documents_sidebar.html.erb
+++ b/app/views/layouts/_documents_sidebar.html.erb
@@ -13,7 +13,7 @@
   </div>
   <div class="accordion-inner">
     <div class="accordion-box-side row">
-      <button class="btn-menu bg-primary accordion-side" ><i class="fas fa-ellipsis-h fa-4x pl-2" style="color: white;" ></i></button>
+      <button class="btn-menu bg-primary accordion-side" ><i class="fas fa-ellipsis-h fa-4x pl-2 text-white" ></i></button>
       <div class="accordion-content-side">
         <button type="botton" class="btn btn-outline-dark btn-lg">
           <%= link_to 'ログアウト', destroy_user_session_path, class: text_color, method: :delete %>

--- a/app/views/layouts/_documents_sidebar.html.erb
+++ b/app/views/layouts/_documents_sidebar.html.erb
@@ -16,7 +16,7 @@
       <button class="btn-menu bg-primary accordion-side" ><i class="fas fa-ellipsis-h fa-4x" style="color: white;" ></i></button>
       <div class="accordion-content-side">
         <button type="botton" class="btn btn-outline-dark btn-lg">
-          <%= link_to 'ログアウト', destroy_user_session_path, class:"text-danger", method: :delete %>
+          <%= link_to 'ログアウト', destroy_user_session_path, class: text_color, method: :delete %>
         </button>
       </div>
     </div>


### PR DESCRIPTION
## 概要
- 表題の通り


## タスク内容
- サイドバーの一番下に三点リーダーアイコンを設置
- クリックしたらログアウトボタン表示するように設定
- ドキュメント詳細画面のログアウトボタンは削除

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub の Files changed で差分を確認
- [x] 影響し得る範囲のローカル環境での動作確認


## 実装画面
![ログアウトボタン](https://user-images.githubusercontent.com/67620156/118119825-ec891e00-b429-11eb-933d-9cfb8a02cdfa.gif)



## その他参考情報
### 実装する上で参考にしたサイト
- [jQueryを使わずにスライドメニューを実装しよう](https://www.webcreatorbox.com/tech/slide-menu)



