### PR TITLE
fix: 編集画面でリアルタイムプレビューがキーを打たないと表示されないので、修正

### DIFF
--- a/app/javascript/packs/documents/real_time_preview.js
+++ b/app/javascript/packs/documents/real_time_preview.js
@@ -3,4 +3,6 @@ $(function () {
     const html = marked($(this).val());
     $("#markdown_preview").html(html);
   });
+  const html = marked($("#markdown_editor_textarea").val());
+  $("#markdown_preview").html(html);
 });


### PR DESCRIPTION
## 概要
- 表題の通り

## タスク内容
- `app/javascript/packs/documents/real_time_preview.js` ファイルを修正

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub の Files changed で差分を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

