### PR TITLE
ドキュメント一覧ページのデザインを変更

### DIFF
--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -56,6 +56,13 @@ ul {
     }
   }
 }
+.index_title {
+  font-size: 2rem;
+}
+
+.documents_title {
+  font-size: 1.5rem;
+}
 
 .create_docuent_button {
   width: 80px;

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -8,7 +8,7 @@
   <div class="row">
     <div class="col-9 row my-4">
       <div class="col-7">
-        <span class="documents_title"><%= link_to document.title, document, class: "text-decoration-none" %></span>
+        <span class="documents_title"><%= link_to document.title.truncate(15), document, class: "text-decoration-none" %></span>
       </div>
       <div class="col-5">
         <span>

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -1,23 +1,35 @@
-<div class="container mt-4 pb-2 border-bottom">
+<div class="container mt-4 pb-2 border-bottom index_title">
+  <i class="fas fa-book text-primary"></i>
   <%= @current_directory_name %>
 </div>
 
 <% @documents.each do |document| %>
-<div class="container px-0 border-bottom">
-  <div class="row mt-2 pt-1 pb-0">
-    <div class="col-8 pl-4 mt-4">
-      <span><%= link_to document.title, document %></span>
-      <span>
-        <%= link_to edit_document_path(document), class: "text-decoration-none" do %>
-        <i class="fas fa-pen ml-2"></i>
-        <% end %>
-        <%= link_to document_path(document), method: :delete do %>
-        <i class="fas fa-trash-alt ml-2"></i>
-        <% end %>
-      </span>
+<div class="container border-bottom">
+  <div class="row">
+    <div class="col-9 row my-4">
+      <div class="col-7">
+        <span class="documents_title"><%= link_to document.title, document, class: "text-decoration-none" %></span>
+      </div>
+      <div class="col-5">
+        <span>
+          <%= link_to edit_document_path(document), class: "text-decoration-none" do %>
+          <button type="button" class="btn btn-primary">
+            <i class="fas fa-pen"></i>
+            <span class="ml-2">編集</span>
+          </button>
+          <% end %>
+          <%= link_to document_path(document), method: :delete do %>
+          <button type="button" class="btn btn-danger">
+            <i class="fas fa-trash-alt"></i>
+            <span class="ml-2">削除</span>
+          </button>
+          <% end %>
+        </span>
+      </div>
     </div>
-    <div class="col-4 text-center mt-4 px-0">
-      <div class>作成者:<%= document.writer.name %>更新日:<%= document.updated_at.strftime('%Y年%m月%d日') %></div>
+    <div class="col-3 d-flex flex-column justify-content-center">
+      <div>作成者:<%= document.writer.name %></div>
+      <div>更新日:<%= document.updated_at.strftime('%Y年%m月%d日') %></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 概要
- 表題の通り

## タスク内容
- 表題に FontAwesome 追加し文字の大きさを２倍に変更
- タイトル、編集ボタン削除ボタン、作成者更新日の各要素の位置をカラムで固定
- 編集、削除ボタンを押しやすいものに変更
- 作成者と更新日を縦で並べる
- タイトルが15文字以上になった場合...と表示するように設定変更

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub の Files changed で差分を確認
- [ ] 影響し得る範囲のローカル環境での動作確認


## 実装画面
![スクリーンショット 2021-05-15 11 21 36](https://user-images.githubusercontent.com/77535025/118345675-1d279f80-b571-11eb-95df-e2a24ac0a323.png)


## その他参考情報
### 実装する上で参考にしたサイト
- [Railsのtruncateの使い方](https://qiita.com/tomoko523/items/7ccd3c9bb97c26ee568b)
