### PR TITLE
フラッシュメッセージをテキストメッセージからBootstrapのアラートに変更

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -64,7 +64,7 @@ class DocumentsController < ApplicationController
 
       @document = current_user.documents.create!(document_elements)
     end
-    redirect_to @document, notice: "ドキュメントを登録しました。"
+    redirect_to @document, flash: { primary: "ドキュメントを登録しました。" }
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
@@ -90,7 +90,7 @@ class DocumentsController < ApplicationController
       @document.update!(document_elements)
       destroy_no_content_directories(past_directories)
     end
-    redirect_to @document, notice: "ドキュメントを更新しました。"
+    redirect_to @document, flash: { primary: "ドキュメントを更新しました。" }
   end
 
   def destroy
@@ -100,7 +100,7 @@ class DocumentsController < ApplicationController
       @document.destroy!
       destroy_no_content_directories(past_directories)
     end
-    redirect_to root_path, alert: "ドキュメントを削除しました"
+    redirect_to root_path, flash: { danger: "ドキュメントを削除しました" }
   end
 
   private

--- a/app/javascript/packs/flash.js
+++ b/app/javascript/packs/flash.js
@@ -1,3 +1,3 @@
-$(function(){
-  setTimeout("$('.flash').fadeOut('slow')", 2000);
+$(function() {
+  setTimeout("$('.flash').fadeOut('slow')", 4000);
 });

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,4 +1,9 @@
 <% flash.each do |flash_type, msg| %>
-  <p style="color: <%= flash_type == 'notice' ? 'green' : 'red' %>;", class="flash text-center"><%= msg%></p>
+  <div class="flash alert alert-<%= flash_type || "primary" %>" style="margin-bottom: 0;" role="alert">
+    <%= msg %>
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
 <% end %>
 <%= javascript_pack_tag 'flash' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
 <body>
   <div class="root_container">
     <% if user_signed_in? %>
-    <%= render "layouts/documents_sidebar" %>
+      <%= render "layouts/documents_sidebar" %>
     <% end %>
     <div class="big_container">
       <%= render partial: 'layouts/flash' %>


### PR DESCRIPTION
## 概要
- #54 削除ボタン押した後にアラートとフラッシュメッセージを表示のデザイン変更案

## チェックリスト
- [x] GitHub の Files changed で差分を確認
- [x] 影響し得る範囲のローカル環境での動作確認


## 実装画面
https://user-images.githubusercontent.com/51290007/118345712-552ee280-b571-11eb-9114-fe473a952c6f.mov

### その他
- マージは #54 のブランチに向けて行っています。
- 不採用の場合はクローズしてもらってOKです。
