### PR TITLE
ドキュメント一覧画面に全てのユーザーのドキュメントを表示

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -35,7 +35,12 @@ class DocumentsController < ApplicationController
   end
 
   def show
-    @document = current_user.have_documents.find(params[:id])
+    # HACK: コミュニティ機能ができたらコメントインする
+    # @document = current_user.have_documents.find(params[:id])
+
+    # HACK: コミュニティ機能ができたら削除
+    @document = Document.find(params[:id])
+
     @directory = @document.user_directory.path.pluck(:name)
   end
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -10,13 +10,27 @@ class DocumentsController < ApplicationController
   end
 
   def index
-    @user_directories = current_user.user_directories.arrange
+    # HACK: コミュニティ機能ができたら削除
+    @user_directories = UserDirectory.arrange
     if params[:directory_id]
-      target_directory = current_user.user_directories.find(params[:directory_id])
+      target_directory = UserDirectory.find(params[:directory_id])
       target_directory_ids = target_directory.descendant_ids.push(target_directory.id)
     end
+
+    # HACK: コミュニティ機能ができたらコメントインする
+    # @user_directories = current_user.user_directories.arrange
+    # if params[:directory_id]
+    #   target_directory = current_user.user_directories.find(params[:directory_id])
+    #   target_directory_ids = target_directory.descendant_ids.push(target_directory.id)
+    # end
+
     # HACK: 分かりやすいコードに改善余地あり
-    @documents = target_directory_ids ? Document.where(user_directory: target_directory_ids) : current_user.have_documents
+    # HACK: コミュニティ機能ができたらコメントインする
+    # @documents = target_directory_ids ? Document.where(user_directory: target_directory_ids) : current_user.have_documents
+
+    # HACK: コミュニティ機能ができたら削除
+    @documents = target_directory_ids ? Document.where(user_directory: target_directory_ids) : Document.all
+
     @current_directory_name = target_directory&.name || "ドキュメント一覧"
   end
 


### PR DESCRIPTION
## 概要
- タイトルの通り


## タスク内容
- ドキュメント一覧画面に表示するドキュメントを全てのユーザーの物に変更
- 他ユーザーのドキュメント詳細も見れるように設定

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub の Files changed で差分を確認
- [x] 影響し得る範囲のローカル環境での動作確認

