### PR TITLE
devise のconfirmations 機能の実装

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -18,14 +18,14 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
 
   protected
 
-  # The path used after resending confirmation instructions.
-  # def after_resending_confirmation_instructions_path_for(resource_name)
-  #   super(resource_name)
-  # end
+    # The path used after resending confirmation instructions.
+    # def after_resending_confirmation_instructions_path_for(resource_name)
+    #   super(resource_name)
+    # end
 
-  # The path used after confirmation.
-  def after_confirmation_path_for(resource_name, resource)
-    token = resource.send(:set_reset_password_token)
-    edit_password_path(resource, reset_password_token: token)
-  end
+    # The path used after confirmation.
+    def after_confirmation_path_for(resource_name, resource)
+      token = resource.send(:set_reset_password_token)
+      edit_password_path(resource, reset_password_token: token)
+    end
 end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  def after_confirmation_path_for(resource_name, resource)
+    token = resource.send(:set_reset_password_token)
+    edit_password_path(resource, reset_password_token: token)
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  protected
+
+  def sign_up_params
+    devise_parameter_sanitizer.sanitize(:sign_up).merge(name: "name")
+  end
+
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -62,8 +62,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   protected
 
-  def sign_up_params
-    devise_parameter_sanitizer.sanitize(:sign_up).merge(name: "name")
-  end
-
+    def sign_up_params
+      devise_parameter_sanitizer.sanitize(:sign_up).merge(name: "name")
+    end
 end

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -158,3 +158,10 @@ th, td {
   color: #41474c;
   box-shadow: 0 2px 3px gray;
 }
+
+// パスワード設定画面のエラーメッセージ
+.error_message {
+  ul {
+    list-style: disc;
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,4 +37,9 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   validates :name, presence: true, length: { maximum: 20 }
+
+  protected
+    def password_required?
+      confirmed? ? super : false
+    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,9 @@
 # Table name: users
 #
 #  id                     :bigint           not null, primary key
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  image                  :string
@@ -10,11 +13,13 @@
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
+#  unconfirmed_email      :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #
 # Indexes
 #
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #
@@ -28,7 +33,7 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :confirmable, :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
   validates :name, presence: true, length: { maximum: 20 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,6 +39,7 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 20 }
 
   protected
+
     def password_required?
       confirmed? ? super : false
     end

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,9 @@
-<p>Welcome <%= @email %>!</p>
+<p><%= @email %>様。</p>
 
-<p>You can confirm your account email through the link below:</p>
+<p>WonderfulPortal へようこそ!</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p>下記のリンクよりパスワードの設定を行い、新規登録を完了してください。</p>
+
+<p>
+  <%= link_to 'パスワードの設定', confirmation_url(@resource, confirmation_token: @token), class: "text-decoration-none"  %>
+</p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,0 +1,25 @@
+<h2>Set your password</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+<%= render "devise/shared/error_messages", resource: resource %>
+<%= f.hidden_field :reset_password_token %>
+
+<div class="field">
+  <%= f.label :password, "New password" %><br />
+  <% if @minimum_password_length %>
+  <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+  <% end %>
+  <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+</div>
+
+<div class="field">
+  <%= f.label :password_confirmation, "Confirm new password" %><br />
+  <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+</div>
+
+<div class="actions">
+  <%= f.submit "Set my password" %>
+</div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,35 +1,30 @@
-<div class="container mt-5">
-  <div style="max-width: 500px;" class="mx-auto">
+ <%= render "devise/shared/error_messages", resource: resource %>
+ <div class="container mt-5">
+   <div style="max-width: 500px;" class="mx-auto">
 
-    <h2>名前とパスワードの設定</h2>
+     <h2>パスワードの設定</h2>
 
-    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-    <%= render "devise/shared/error_messages", resource: resource %>
-    <%= f.hidden_field :reset_password_token %>
+     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+     <%= f.hidden_field :reset_password_token %>
 
-    <div class="form-group mb-2">
-      <%= f.label :name %><br />
-      <%= f.text_field :name, autofocus: true, autocomplete: "name", :class => "form-control" %>
-    </div>
+     <div class="field">
+       <%= f.label :password, "パスワードの設定" %>
+       <% if @minimum_password_length %>
+       <em>(<%= @minimum_password_length %> 文字以上で入力ください)</em>
+       <% end %>
+       <%= f.password_field :password, autofocus: true, autocomplete: "new-password", :class => "form-control" %>
+     </div>
 
-    <div class="field">
-      <%= f.label :password, "パスワードの設定" %>
-      <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> 文字以上で入力ください)</em><br />
-      <% end %>
-      <%= f.password_field :password, autofocus: true, autocomplete: "new-password", :class => "form-control" %>
-    </div>
+     <div class="field">
+       <%= f.label :password_confirmation, "パスワード確認用" %><br />
+       <%= f.password_field :password_confirmation, autocomplete: "new-password", :class => "form-control" %>
+     </div>
 
-    <div class="field">
-      <%= f.label :password_confirmation, "パスワード確認用" %><br />
-      <%= f.password_field :password_confirmation, autocomplete: "new-password", :class => "form-control" %>
-    </div>
+     <div class="actions pt-4">
+       <%= f.submit "登録完了", :class => "btn btn-primary btn-block" %>
+     </div>
+     <% end %>
 
-    <div class="actions pt-4">
-      <%= f.submit "登録完了", :class => "btn btn-primary btn-block" %>
-    </div>
-    <% end %>
-
-    <%= render "devise/shared/links" %>
-  </div>
-</div>
+     <%= render "devise/shared/links" %>
+   </div>
+ </div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,35 @@
-<h2>Set your password</h2>
+<div class="container mt-5">
+  <div style="max-width: 500px;" class="mx-auto">
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-<%= render "devise/shared/error_messages", resource: resource %>
-<%= f.hidden_field :reset_password_token %>
+    <h2>名前とパスワードの設定</h2>
 
-<div class="field">
-  <%= f.label :password, "New password" %><br />
-  <% if @minimum_password_length %>
-  <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-  <% end %>
-  <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+    <%= f.hidden_field :reset_password_token %>
+
+    <div class="form-group mb-2">
+      <%= f.label :name %><br />
+      <%= f.text_field :name, autofocus: true, autocomplete: "name", :class => "form-control" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password, "パスワードの設定" %>
+      <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> 文字以上で入力ください)</em><br />
+      <% end %>
+      <%= f.password_field :password, autofocus: true, autocomplete: "new-password", :class => "form-control" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password_confirmation, "パスワード確認用" %><br />
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", :class => "form-control" %>
+    </div>
+
+    <div class="actions pt-4">
+      <%= f.submit "登録完了", :class => "btn btn-primary btn-block" %>
+    </div>
+    <% end %>
+
+    <%= render "devise/shared/links" %>
+  </div>
 </div>
-
-<div class="field">
-  <%= f.label :password_confirmation, "Confirm new password" %><br />
-  <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-</div>
-
-<div class="actions">
-  <%= f.submit "Set my password" %>
-</div>
-<% end %>
-
-<%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,27 +4,9 @@
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
 
-    <div class="form-group mb-2">
-      <%= f.label :name %><br />
-      <%= f.text_field :name, autofocus: true, autocomplete: "name", :class => "form-control" %>
-    </div>
-
     <div class="form-group">
       <%= f.label :email %><br />
       <%= f.email_field :email, autofocus: true, autocomplete: "email", :class => "form-control" %>
-    </div>
-
-    <div class="form-group">
-      <%= f.label :password %>
-      <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> 文字以上で入力ください)</em>
-      <% end %><br />
-      <%= f.password_field :password, autocomplete: "new-password", :class => "form-control" %>
-    </div>
-
-    <div class="form-group">
-      <%= f.label :password_confirmation %><br />
-      <%= f.password_field :password_confirmation, autocomplete: "new-password", :class => "form-control" %>
     </div>
 
     <div class="actions pt-4">

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,0 +1,15 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation">
+    <h2>
+      <%= I18n.t("errors.messages.not_saved",
+                 count: resource.errors.count,
+                 resource: resource.class.model_name.human.downcase)
+       %>
+    </h2>
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,15 +1,15 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation">
-    <h2>
-      <%= I18n.t("errors.messages.not_saved",
+<div id="error_explanation" class="error_message">
+  <div>
+    <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
-    </h2>
-    <ul>
-      <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
   </div>
+  <ul>
+    <% resource.errors.full_messages.each do |message| %>
+    <li><%= message %></li>
+    <% end %>
+  </ul>
+</div>
 <% end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,6 +52,8 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
+  config.action_mailer.default_url_options = { host: "localhost:3000" }
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -88,8 +88,8 @@ ja:
       no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
       send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
       send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
-      updated: パスワードが正しく変更されました。
-      updated_not_active: パスワードが正しく変更されました。
+      updated: パスワードの設定が完了しました.
+      updated_not_active: パスワードの設定が完了しました。
     registrations:
       destroyed: アカウントを削除しました。またのご利用をお待ちしております。
       edit:

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -43,7 +43,7 @@ ja:
       locked: アカウントはロックされています。
       not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
       timeout: セッションがタイムアウトしました。もう一度ログインしてください。
-      unauthenticated: アカウント認証メールを送信しました。
+      unauthenticated: アカウント登録もしくはログインしてください。
       unconfirmed: メールアドレスの本人確認が必要です。
     mailer:
       confirmation_instructions:

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -21,7 +21,7 @@ ja:
         remember_created_at: ログイン記憶時刻
         remember_me: ログインを記憶する
         reset_password_sent_at: パスワードリセット送信時刻
-        reset_password_token: パスワードリセット用トークン
+        reset_password_token: パスワード設定
         sign_in_count: ログイン回数
         unconfirmed_email: 未確認Eメール
         unlock_token: ロック解除用トークン
@@ -43,7 +43,7 @@ ja:
       locked: アカウントはロックされています。
       not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
       timeout: セッションがタイムアウトしました。もう一度ログインしてください。
-      unauthenticated: アカウント登録もしくはログインしてください。
+      unauthenticated: アカウント認証メールを送信しました。
       unconfirmed: メールアドレスの本人確認が必要です。
     mailer:
       confirmation_instructions:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
-  devise_for :users, skip: "passwords"
+  devise_for :users, controllers: {
+    confirmations: "users/confirmations"
+  }
   root "documents#index"
   resources :documents
   resources :document_images, only: [:create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   devise_for :users, controllers: {
-    confirmations: "users/confirmations"
+    confirmations: "users/confirmations",
+    registrations: "users/registrations"
   }
   root "documents#index"
   resources :documents

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   devise_for :users, controllers: {
     confirmations: "users/confirmations",
-    registrations: "users/registrations"
+    registrations: "users/registrations",
   }
   root "documents#index"
   resources :documents

--- a/db/migrate/20210419131418_devise_create_users.rb
+++ b/db/migrate/20210419131418_devise_create_users.rb
@@ -24,10 +24,10 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.1]
       # t.string   :last_sign_in_ip
 
       ## Confirmable
-      # t.string   :confirmation_token
-      # t.datetime :confirmed_at
-      # t.datetime :confirmation_sent_at
-      # t.string   :unconfirmed_email # Only if using reconfirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
 
       ## Lockable
       # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
@@ -39,7 +39,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.1]
 
     add_index :users, :email,                unique: true
     add_index :users, :reset_password_token, unique: true
-    # add_index :users, :confirmation_token,   unique: true
+    add_index :users, :confirmation_token,   unique: true
     # add_index :users, :unlock_token,         unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -98,8 +98,13 @@ ActiveRecord::Schema.define(version: 2021_05_09_060919) do
     t.string "name", null: false
     t.string "image"
     t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,6 +3,9 @@
 # Table name: users
 #
 #  id                     :bigint           not null, primary key
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  image                  :string
@@ -10,11 +13,13 @@
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
+#  unconfirmed_email      :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #
 # Indexes
 #
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -52,14 +52,6 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context "passwordが入力されていない時" do
-      let(:user) { build(:user, password: nil) }
-      it "ユーザーが作成されない" do
-        expect(subject).not_to be_valid
-        expect(subject.errors.details[:password][0][:error]).to eq :blank
-      end
-    end
-
     context "nameが20文字以下の時" do
       let(:user) { build(:user, name: "A" * 20) }
       it "ユーザーが作成される" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,9 @@
 # Table name: users
 #
 #  id                     :bigint           not null, primary key
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  image                  :string
@@ -10,11 +13,13 @@
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
+#  unconfirmed_email      :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #
 # Indexes
 #
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #


### PR DESCRIPTION
## 概要
- 表題の通り


## タスク内容
- confirmation の有効化
- メールアドレスを登録した際に、仮で name に値が入るように実装
- confirmation 設定に応じたviews ファイルの内容変更
- 送信メールの文面の変更
- パスワード設定画面用のアラートメッセージファイルの作成と編集

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub の Files changed で差分を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

## 実装画面
![パスワード認証 gif](https://user-images.githubusercontent.com/77535025/119239542-c2033780-bb84-11eb-9e0b-cff323da0ed6.gif)

## 参考サイト
[devise wiki メールアドレスのみで仮登録する方法](https://github.com/heartcombo/devise/wiki/How-To:-Email-only-sign-up)
