### PR TITLE
ページネーション機能の実装

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -31,7 +31,8 @@ class DocumentsController < ApplicationController
     # @documents = target_directory_ids ? Document.where(user_directory: target_directory_ids) : current_user.have_documents
 
     # HACK: コミュニティ機能ができたら削除
-    @documents = target_directory_ids ? Document.where(user_directory: target_directory_ids).page(params[:page]).per(PER_PAGE) : Document.page(params[:page]).per(PER_PAGE)
+    @documents_judge = target_directory_ids ? Document.where(user_directory: target_directory_ids) : Document.all
+    @documents = @documents_judge.page(params[:page]).per(PER_PAGE)
 
     @current_directory_name = target_directory&.name || "ドキュメント一覧"
   end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,4 +1,6 @@
 class DocumentsController < ApplicationController
+  PER_PAGE = 8
+
   def new
     @document = current_user.documents.new
   end
@@ -29,7 +31,7 @@ class DocumentsController < ApplicationController
     # @documents = target_directory_ids ? Document.where(user_directory: target_directory_ids) : current_user.have_documents
 
     # HACK: コミュニティ機能ができたら削除
-    @documents = target_directory_ids ? Document.where(user_directory: target_directory_ids) : Document.all
+    @documents = target_directory_ids ? Document.where(user_directory: target_directory_ids).page(params[:page]).per(PER_PAGE) : Document.page(params[:page]).per(PER_PAGE)
 
     @current_directory_name = target_directory&.name || "ドキュメント一覧"
   end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -31,8 +31,8 @@ class DocumentsController < ApplicationController
     # @documents = target_directory_ids ? Document.where(user_directory: target_directory_ids) : current_user.have_documents
 
     # HACK: コミュニティ機能ができたら削除
-    @documents_judge = target_directory_ids ? Document.where(user_directory: target_directory_ids) : Document.all
-    @documents = @documents_judge.page(params[:page]).per(PER_PAGE)
+    @documents = target_directory_ids ? Document.where(user_directory: target_directory_ids) : Document.all
+    @documents = @documents.page(params[:page]).per(PER_PAGE)
 
     @current_directory_name = target_directory&.name || "ドキュメント一覧"
   end

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -147,3 +147,14 @@ th, td {
   white-space: nowrap;
   text-align: left;
 }
+
+
+// ページネーション
+.page-item:not(:first-child) {
+  margin-left: 10px;
+}
+
+.page-link {
+  color: #41474c;
+  box-shadow: 0 2px 3px gray;
+}

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -8,7 +8,7 @@
   <div class="row">
     <div class="col-9 row my-4">
       <div class="col-7">
-        <span class="documents_title"><%= link_to document.title.truncate(15), document, class: "text-decoration-none" %></span>
+        <span class="documents_title"><%= link_to document.title.truncate(15), document, class: "text-decoration-none text-dark" %></span>
       </div>
       <div class="col-5">
         <span>

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -34,3 +34,4 @@
   </div>
 </div>
 <% end %>
+<%= paginate @documents %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -8,6 +8,5 @@
     <div id="directory_document">
       <%= render partial: 'document', locals: { documents: @documents } %>
     </div>
-    <%= paginate @documents %>
   </div>
 </div>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -8,5 +8,6 @@
     <div id="directory_document">
       <%= render partial: 'document', locals: { documents: @documents } %>
     </div>
+    <%= paginate @documents %>
   </div>
 </div>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,10 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,18 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,25 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -8,7 +8,7 @@
 -%>
 <%= paginator.render do %>
   <nav>
-    <ul class="pagination">
+    <ul class="pagination mt-5 justify-content-center">
       <%= first_page_tag unless current_page.first? %>
       <%= prev_page_tag unless current_page.first? %>
       <% each_page do |page| %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -5,8 +5,8 @@ Kaminari.configure do |config|
   # config.max_per_page = nil
   # config.window = 4
   # config.outer_window = 0
-  # config.left = 0
-  # config.right = 0
+  config.left = 3
+  config.right = 3
   # config.page_method_name = :page
   # config.param_name = :page
   # config.max_pages = nil

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,3 +9,10 @@ ja:
       rmagick_processing_error: "rmagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
       mime_types_processing_error: "MIME::Typesのファイルを処理できませんでした。Content-Typeを確認してください。エラーメッセージ: %{e}"
       mini_magick_processing_error: "MiniMagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
+  views:
+    pagination:
+      first: "<<"
+      last: ">>"
+      previous: "<"
+      next: ">"
+      truncate: "..."


### PR DESCRIPTION
## 概要
- ドキュメント一覧画面にページネーションを追加

## タスク内容
- `documents_controller.rb`にページネーションを定義
  - ドキュメントは8件表示できるように設定
- `_document.html.erb`の下部にページネーションを表示
- `app/views/kaminari`以下にページネーションカスタマイズ用のファイルを作成
- ページネーションのデザインを調整

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub の Files changed で差分を確認
- [x] 影響し得る範囲のローカル環境での動作確認


## 実装画面
![スクリーンショット 2021-05-20 9 28 15](https://user-images.githubusercontent.com/67620156/118903012-c0056280-b951-11eb-9561-ee3759563ccd.png)


## その他参考情報
### 実装する上で参考にしたサイト
- [【公式】GitHub](https://github.com/kaminari/kaminari)
- [【Rails】ページネーション「kaminari」で用意されているテーマ一覧とスタイルのカスタマイズ](https://www.autovice.jp/articles/139)

### ドキュメント
- []()

### その他
- ドキュメント一覧画面の各ドキュメントタイトルのテキストカラーも変更していますので、合わせてご確認お願いします！
