### PR TITLE
バリデーションエラーメッセージをフロントに表示

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -86,10 +86,10 @@ class DocumentsController < ApplicationController
       }
       @document = current_user.documents.create!(document_elements)
     end
-      redirect_to @document, flash: { primary: "ドキュメントを登録しました。" }
-    rescue ActiveRecord::RecordInvalid => e
-      @error_messages = e.record.errors.full_messages
-      render :new
+    redirect_to @document, flash: { primary: "ドキュメントを登録しました。" }
+  rescue ActiveRecord::RecordInvalid => e
+    @error_messages = e.record.errors.full_messages
+    render :new
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
@@ -115,10 +115,10 @@ class DocumentsController < ApplicationController
       @document.update!(document_elements)
       destroy_no_content_directories(past_directories)
     end
-      redirect_to @document, flash: { primary: "ドキュメントを更新しました。" }
-    rescue ActiveRecord::RecordInvalid => e
-      @error_messages = e.record.errors.full_messages
-      render :edit
+    redirect_to @document, flash: { primary: "ドキュメントを更新しました。" }
+  rescue ActiveRecord::RecordInvalid => e
+    @error_messages = e.record.errors.full_messages
+    render :edit
   end
 
   def destroy

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -83,11 +83,11 @@ class DocumentsController < ApplicationController
         owner: current_user,
         user_directory: prev_directory,
       }
-      @document = current_user.documents.new(document_elements)
-      @document = @document.save!
+      @document = current_user.documents.create!(document_elements)
     end
       redirect_to @document, flash: { primary: "ドキュメントを登録しました。" }
-    rescue => e
+    rescue ActiveRecord::RecordInvalid => e
+      @error_messages = e.record.errors.full_messages
       render :new
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,5 +1,6 @@
 class DocumentsController < ApplicationController
   PER_PAGE = 8
+  rescue_from ActiveRecord::RecordNotFound, with: :redirect_to_toppage
 
   def new
     @document = current_user.documents.new
@@ -136,5 +137,9 @@ class DocumentsController < ApplicationController
       target_directories.each do |directory|
         directory.do_not_have? ? directory.destroy! : break
       end
+    end
+
+    def redirect_to_toppage
+      redirect_to :root, flash: { danger: "このドキュメントは自分のではないため編集できません。" }
     end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -115,8 +115,9 @@ class DocumentsController < ApplicationController
       destroy_no_content_directories(past_directories)
     end
       redirect_to @document, flash: { primary: "ドキュメントを更新しました。" }
-    rescue => e
-      render :new
+    rescue ActiveRecord::RecordInvalid => e
+      @error_messages = e.record.errors.full_messages
+      render :edit
   end
 
   def destroy

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,6 +1,5 @@
 class DocumentsController < ApplicationController
   PER_PAGE = 8
-  rescue_from ActiveRecord::RecordNotFound, with: :redirect_to_toppage
 
   def new
     @document = current_user.documents.new
@@ -137,9 +136,5 @@ class DocumentsController < ApplicationController
       target_directories.each do |directory|
         directory.do_not_have? ? directory.destroy! : break
       end
-    end
-
-    def redirect_to_toppage
-      redirect_to :root, flash: { danger: "このドキュメントは自分のではないため編集できません。" }
     end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -83,9 +83,13 @@ class DocumentsController < ApplicationController
         owner: current_user,
         user_directory: prev_directory,
       }
-      @document = current_user.documents.create!(document_elements)
+      @document = current_user.documents.new(document_elements)
+      if @document.save
+        redirect_to @document, flash: { primary: "ドキュメントを登録しました。" }
+      else
+        render :new
+      end
     end
-    redirect_to @document, flash: { primary: "ドキュメントを登録しました。" }
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -84,12 +84,11 @@ class DocumentsController < ApplicationController
         user_directory: prev_directory,
       }
       @document = current_user.documents.new(document_elements)
-      if @document.save
-        redirect_to @document, flash: { primary: "ドキュメントを登録しました。" }
-      else
-        render :new
-      end
+      @document = @document.save!
     end
+      redirect_to @document, flash: { primary: "ドキュメントを登録しました。" }
+    rescue => e
+      render :new
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
@@ -112,13 +111,12 @@ class DocumentsController < ApplicationController
         body: body,
         user_directory: prev_directory,
       }
-      if @document.update(document_elements)
-        destroy_no_content_directories(past_directories)
-        redirect_to @document, flash: { primary: "ドキュメントを更新しました。" }
-      else
-        render action: :edit
-      end
+      @document.update!(document_elements)
+      destroy_no_content_directories(past_directories)
     end
+      redirect_to @document, flash: { primary: "ドキュメントを更新しました。" }
+    rescue => e
+      render :new
   end
 
   def destroy

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -112,10 +112,13 @@ class DocumentsController < ApplicationController
         body: body,
         user_directory: prev_directory,
       }
-      @document.update!(document_elements)
-      destroy_no_content_directories(past_directories)
+      if @document.update(document_elements)
+        destroy_no_content_directories(past_directories)
+        redirect_to @document, flash: { primary: "ドキュメントを更新しました。" }
+      else
+        render action: :edit
+      end
     end
-    redirect_to @document, flash: { primary: "ドキュメントを更新しました。" }
   end
 
   def destroy

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -1,2 +1,9 @@
 module DocumentsHelper
+  def button_text
+    if action_name == "new"
+      "作成"
+    elsif action_name == "edit"
+      "更新"
+    end
+  end
 end

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -8,6 +8,6 @@ module DocumentsHelper
   end
 
   def value_text
-    action_name == "edit" ? "#{@all_directories}/#{@title}" : ""
+    action_name == "edit" ? "#{@all_directories}/#{@title}" : ""  # rubocop:disable  Rails/HelperInstanceVariable
   end
 end

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -1,9 +1,5 @@
 module DocumentsHelper
 
-  def placeholder_text
-    action_name == "new" ? "タイトル" : ""
-  end
-
   def value_text
     action_name == "edit" ? "#{@all_directories}/#{@title}" : ""  # rubocop:disable  Rails/HelperInstanceVariable
   end

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -4,6 +4,10 @@ module DocumentsHelper
   end
 
   def placeholder_text
-    action_name == "new" ? "タイトル" : "#{@all_directories}/#{@title}"
+    action_name == "new" ? "タイトル" : ""
+  end
+
+  def value_text
+    action_name == "edit" ? "#{@all_directories}/#{@title}" : ""
   end
 end

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -2,4 +2,8 @@ module DocumentsHelper
   def button_text
     action_name == "new" ? "作成" : "更新"
   end
+
+  def placeholder_text
+    action_name == "new" ? "タイトル" : "#{@all_directories}/#{@title}"
+  end
 end

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -1,7 +1,4 @@
 module DocumentsHelper
-  def button_text
-    action_name == "new" ? "作成" : "更新"
-  end
 
   def placeholder_text
     action_name == "new" ? "タイトル" : ""

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -1,9 +1,5 @@
 module DocumentsHelper
   def button_text
-    if action_name == "new"
-      "作成"
-    elsif action_name == "edit"
-      "更新"
-    end
+    action_name == "new" ? "作成" : "更新"
   end
 end

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -1,5 +1,4 @@
 module DocumentsHelper
-
   def value_text
     action_name == "edit" ? "#{@all_directories}/#{@title}" : ""  # rubocop:disable  Rails/HelperInstanceVariable
   end

--- a/app/validators/ancestry_validator.rb
+++ b/app/validators/ancestry_validator.rb
@@ -2,7 +2,7 @@ class AncestryValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     # HACK: /で判断させるのは直感的ではないため別の方法も検討する
     if value.count("/") > 3
-      record.errors.add("ディレクトリは6つ以上作成できません！")
+      record.errors.add(attribute, "ディレクトリは6つ以上作成できません！")
     end
   end
 end

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -11,20 +11,22 @@
         <span class="documents_title"><%= link_to document.title.truncate(15), document, class: "text-decoration-none text-dark" %></span>
       </div>
       <div class="col-5">
-        <span>
-          <%= link_to edit_document_path(document), class: "text-decoration-none" do %>
-          <button type="button" class="btn btn-primary">
-            <i class="fas fa-pen"></i>
-            <span class="ml-2">編集</span>
-          </button>
-          <% end %>
-          <%= link_to document_path(document), method: :delete, data: { confirm: "ドキュメントを削除してもよろしいですか？" } do %>
-          <button type="button" class="btn btn-danger">
-            <i class="fas fa-trash-alt"></i>
-            <span class="ml-2">削除</span>
-          </button>
-          <% end %>
-        </span>
+        <% if document.writer_id == current_user.id %>
+          <span>
+            <%= link_to edit_document_path(document), class: "text-decoration-none" do %>
+            <button type="button" class="btn btn-primary">
+              <i class="fas fa-pen"></i>
+              <span class="ml-2">編集</span>
+            </button>
+            <% end %>
+            <%= link_to document_path(document), method: :delete, data: { confirm: "ドキュメントを削除してもよろしいですか？" } do %>
+            <button type="button" class="btn btn-danger">
+              <i class="fas fa-trash-alt"></i>
+              <span class="ml-2">削除</span>
+            </button>
+            <% end %>
+          </span>
+        <% end %>
       </div>
     </div>
     <div class="col-3 d-flex flex-column justify-content-center">

--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_with model:document, local: true, id: "form" do |f| %>
+  <div class="row">
+    <div class="col-12">
+      <div class='form-group mt-3 pr-3'>
+        <%= f.label :タイトル %>
+        <%= f.text_field :title, class: 'form-control', value: value_text %>
+        <% if @error_messages.present? %>
+          <p style="color: red;"><%= @error_messages.first %></p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+  <div class="row document_body pr-3">
+    <div class="col-6 border-right">
+      <div class='form-group'>
+        <%= f.label :本文 %>
+        <%= f.text_area :body, rows: 10, class: 'form-control input_body', id: 'markdown_editor_textarea', placeholder: '本文を書いていきましょう' %>
+      </div>
+      <div class='form-group'>
+        <%= f.label :画像を添付 %>
+        <%= f.file_field :image, multiple: true, id: 'image' %>
+      </div>
+      <div class="text-right">
+        <%= f.submit class: 'btn btn-primary create_docuent_button' %>
+      </div>
+    </div>
+    <div class="col-6">
+      <div>プレビュー</div>
+      <div id="markdown_preview" class="preview border mt-2"></div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -5,32 +5,7 @@
       ドキュメント編集
     </h2>
   </div>
-
-  <%= form_with model:@document, local: true do |f| %>
-  <div class="row">
-    <div class="col-12">
-      <div class='form-group mt-3 pr-3'>
-        <%= f.label :タイトル %>
-        <%= f.text_field :title, class: 'form-control', value: "#{@all_directories}/#{@title}" %>
-      </div>
-    </div>
-  </div>
-  <div class="row document_body pr-3">
-    <div class="col-6 border-right">
-      <div class='form-group'>
-        <%= f.label :本文 %>
-        <%= f.text_area :body, rows: 10, class: 'form-control input_body', id: 'markdown_editor_textarea' %>
-      </div>
-      <div class="text-right mb-5">
-        <%= f.submit '更新', class: 'btn btn-primary create_docuent_button' %>
-        <% end %>
-      </div>
-    </div>
-    <div class="col-6">
-      <div>プレビュー</div>
-      <div id="markdown_preview" class="preview border mt-2"></div>
-    </div>
-  </div>
+  <%= render partial: 'form', locals: { document: @document } %>
 </div>
 <%= javascript_pack_tag 'documents/real_time_preview.js' %>
 <%= javascript_pack_tag 'documents/fileupload.js' %>

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -5,31 +5,7 @@
       ドキュメント作成
     </h2>
   </div>
-  <%= form_with model:@document, id: "form" do |f| %>
-  <div class="row">
-    <div class="col-12">
-      <div class='form-group mt-3 pr-3'>
-        <%= f.label :タイトル %>
-        <%= f.text_field :title, class: 'form-control', placeholder: 'タイトル' %>
-      </div>
-    </div>
-  </div>
-  <div class="row document_body pr-3">
-    <div class="col-6 border-right">
-      <div class='form-group'>
-        <%= f.label :本文 %>
-        <%= f.text_area :body, rows: 10, class: 'form-control input_body', id: 'markdown_editor_textarea', placeholder: '本文を書いていきましょう' %>
-      </div>
-      <div class="text-right">
-        <%= f.submit '作成', class: 'btn btn-primary create_docuent_button' %>
-        <% end %>
-      </div>
-    </div>
-    <div class="col-6">
-      <div>プレビュー</div>
-      <div id="markdown_preview" class="preview border mt-2"></div>
-    </div>
-  </div>
+  <%= render partial: 'form', locals: { document: @document } %>
 </div>
 <%= javascript_pack_tag 'documents/real_time_preview.js' %>
 <%= javascript_pack_tag 'documents/fileupload.js' %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -16,3 +16,7 @@ ja:
       previous: "<"
       next: ">"
       truncate: "..."
+  helpers:
+    submit:
+      create: 作成
+      update: 更新

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -16,7 +16,201 @@ ja:
       previous: "<"
       next: ">"
       truncate: "..."
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
   helpers:
+    select:
+      prompt: 選択してください
     submit:
       create: 作成
+      submit: 保存
       update: 更新
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後


### PR DESCRIPTION
## 概要
- 表題の通り


## タスク内容
- ドキュメント作成フォームを部分テンプレート化
  - 新規作成と編集で表示が変わるようにヘルパーメソッドを定義
- 以下の場合にエラーメッセージを表示
  - ドキュメント作成時にタイトル未入力 or 50文字以上
  - ドキュメント編集時にタイトル未入力 or 50文字以上
  - ディレクトリ名が20文字以上
  - ディレクトリの階層が5階層以上
  - 他ユーザーのドキュメントを編集しようとした時

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub の Files changed で差分を確認
- [ ] 影響し得る範囲のローカル環境での動作確認


## 実装画面
![スクリーンショット 2021-05-24 23 27 30](https://user-images.githubusercontent.com/67620156/119500160-7332e900-bda2-11eb-8063-7658e820849b.png)

![他ユーザードキュメントでエラー](https://user-images.githubusercontent.com/67620156/119500461-cefd7200-bda2-11eb-877e-615dfd11da15.gif)



## その他参考情報
### 実装する上で参考にしたサイト
- [Rails での例外処理](https://hene.dev/blog/2019/02/04/rails-exception-handling)
- [Rails tips: rescue_fromでコントローラのエラーをrescueする（翻訳）](https://techracho.bpsinc.jp/hachi8833/2018_04_09/54676)

### ドキュメント
- []()

### その他
- エラーメッセージのカスタマイズは別タスクでしたいと思います！
