### PR TITLE
バリデーションエラーメッセージの表示方法を変更

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -87,8 +87,8 @@ class DocumentsController < ApplicationController
     end
     redirect_to @document, flash: { primary: "ドキュメントを登録しました。" }
   rescue ActiveRecord::RecordInvalid => e
-    @error_messages = e.record.errors.full_messages
-    render :new
+    @error_messages = e.record.errors.full_messages.first
+    redirect_to new_document_path, flash: { danger: @error_messages }
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
@@ -116,8 +116,8 @@ class DocumentsController < ApplicationController
     end
     redirect_to @document, flash: { primary: "ドキュメントを更新しました。" }
   rescue ActiveRecord::RecordInvalid => e
-    @error_messages = e.record.errors.full_messages
-    render :edit
+    @error_messages = e.record.errors.full_messages.first
+    redirect_to edit_document_path, flash: { danger: @error_messages }
   end
 
   def destroy

--- a/app/validators/ancestry_validator.rb
+++ b/app/validators/ancestry_validator.rb
@@ -2,7 +2,7 @@ class AncestryValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     # HACK: /で判断させるのは直感的ではないため別の方法も検討する
     if value.count("/") > 3
-      record.errors.add(attribute, "ディレクトリは6つ以上作成できません！")
+      record.errors[:base] << "ディレクトリは5階層までしか作成できません"
     end
   end
 end

--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -4,9 +4,6 @@
       <div class='form-group mt-3 pr-3'>
         <%= f.label :タイトル %>
         <%= f.text_field :title, class: 'form-control', value: value_text %>
-        <% if @error_messages.present? %>
-          <p style="color: red;"><%= @error_messages.first %></p>
-        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -7,11 +7,13 @@
       <h1 class="d-inline">
         <%= @document.title %>
       </h1>
-      <%= link_to edit_document_path, class: "text-decoration-none" do %>
-      <i class="fas fa-pen fa-2x pb-1 ml-2"></i>
-      <% end %>
-      <%= link_to document_path(@document), method: :delete, data: { confirm: "ドキュメントを削除してもよろしいですか？" } do %>
-      <i class="fas fa-trash-alt fa-2x pb-1 ml-2"></i>
+      <% if @document.writer_id == current_user.id %>
+        <%= link_to edit_document_path, class: "text-decoration-none" do %>
+          <i class="fas fa-pen fa-2x pb-1 ml-2"></i>
+        <% end %>
+        <%= link_to document_path(@document), method: :delete, data: { confirm: "ドキュメントを削除してもよろしいですか？" } do %>
+          <i class="fas fa-trash-alt fa-2x pb-1 ml-2"></i>
+        <% end %>
       <% end %>
     </div>
     <div class="col col-4 text-center">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,14 +1,20 @@
 ja:
-  errors:
-    messages:
-      carrierwave_processing_error: 処理できませんでした
-      carrierwave_integrity_error: は許可されていないファイルタイプです
-      carrierwave_download_error: はダウンロードできません
-      extension_white_list_error: "%{extension}ファイルのアップロードは許可されていません。アップロードできるファイルタイプ: %{allowed_types}"
-      extension_black_list_error: "%{extension}ファイルのアップロードは許可されていません。アップロードできないファイルタイプ: %{prohibited_types}"
-      rmagick_processing_error: "rmagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
-      mime_types_processing_error: "MIME::Typesのファイルを処理できませんでした。Content-Typeを確認してください。エラーメッセージ: %{e}"
-      mini_magick_processing_error: "MiniMagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
+  activerecord:
+    errors:
+      messages:
+        carrierwave_processing_error: 処理できませんでした
+        carrierwave_integrity_error: は許可されていないファイルタイプです
+        carrierwave_download_error: はダウンロードできません
+        extension_white_list_error: "%{extension}ファイルのアップロードは許可されていません。アップロードできるファイルタイプ: %{allowed_types}"
+        extension_black_list_error: "%{extension}ファイルのアップロードは許可されていません。アップロードできないファイルタイプ: %{prohibited_types}"
+        rmagick_processing_error: "rmagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
+        mime_types_processing_error: "MIME::Typesのファイルを処理できませんでした。Content-Typeを確認してください。エラーメッセージ: %{e}"
+        mini_magick_processing_error: "MiniMagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
+    attributes:
+      user_directory:
+        name: ディレクトリ名
+      document:
+        title: タイトル
   views:
     pagination:
       first: "<<"


### PR DESCRIPTION
## 概要
- タイトルの通り


## タスク内容
- バリデーションエラーメッセージの日本語化
- バリデーションエラーメッセージをフラッシュで表示
- ドキュメント詳細画面で他ユーザーのドキュメントには編集、削除ボタンは表示されないように設定

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub の Files changed で差分を確認
- [x] 影響し得る範囲のローカル環境での動作確認


## 実装画面
![バリデーションエラー　フラッシュ](https://user-images.githubusercontent.com/67620156/119770537-48a67480-bef7-11eb-8936-692dcefe4282.gif)


## その他参考情報
### 実装する上で参考にしたサイト
- [Railsでcreate後にrenderするとパスが変わるのは何故か](https://losenotime.jp/render/)

