### PR TITLE
ActionMailerにGmailのSMTPサーバーを使う設定

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,6 +68,18 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
+  # ActionMailerにGmailのSMTPサーバーを使う設定
+  config.action_mailer.default_url_options = { host: ENV["DOMAIN"] }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    domain: "gmail.com",
+    port: 587,
+    user_name: ENV["GMAIL_ADDRESS"],
+    password: ENV["GMAIL_APP_PASSWORD"],
+    authentication: "plain",
+  }
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true


### PR DESCRIPTION
## 概要
- 表題のとおり


## タスク内容
- `config/initilizers/production.rb` にActionMailerの設定を記述

## チェックリスト
- [x] GitHub の Files changed で差分を確認
- [x] 影響し得る範囲のローカル環境での動作確認


## その他参考情報
### 実装する上で参考にしたサイト
- [Railsガイド - Gmail用のAction Mailer設定](https://railsguides.jp/action_mailer_basics.html#gmail%E7%94%A8%E3%81%AEaction-mailer%E8%A8%AD%E5%AE%9A)