### PR TITLE
 jQueryでバリデーションメッセージを表示

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -86,9 +86,6 @@ class DocumentsController < ApplicationController
       @document = current_user.documents.create!(document_elements)
     end
     redirect_to @document, flash: { primary: "ドキュメントを登録しました。" }
-  rescue ActiveRecord::RecordInvalid => e
-    @error_messages = e.record.errors.full_messages
-    render :new
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
@@ -115,9 +112,6 @@ class DocumentsController < ApplicationController
       destroy_no_content_directories(past_directories)
     end
     redirect_to @document, flash: { primary: "ドキュメントを更新しました。" }
-  rescue ActiveRecord::RecordInvalid => e
-    @error_messages = e.record.errors.full_messages
-    render :edit
   end
 
   def destroy

--- a/app/javascript/packs/documents/validation.js
+++ b/app/javascript/packs/documents/validation.js
@@ -16,13 +16,6 @@ $(function() {
       validation.text("");
     }
 
-    let result = false;
-    $.each(directory, function(index, value) {
-      if (value.length > 20) {
-        result = true;
-        return false;
-      }
-    });
-    if (result) { validation.text('ディレクトリ名は20文字以内です'); }
+    $.each(directory, (index, value) => { if(value.length > 20) { validation.text('ディレクトリ名は20文字以内です') } });
   });
 });

--- a/app/javascript/packs/documents/validation.js
+++ b/app/javascript/packs/documents/validation.js
@@ -3,7 +3,7 @@ $(function() {
     const value = $(this).val();
     const directory = value.split("/")
     const title = directory.slice(-1)[0]
-    const validation = $(this).next();
+    const validation = $("#title-error-message");
 
     if (value == "" || !value.match(/[^\s\t]/)) {
       validation.text('タイトルを入力してください！');

--- a/app/javascript/packs/documents/validation.js
+++ b/app/javascript/packs/documents/validation.js
@@ -3,16 +3,17 @@ $(function() {
     let value = $(this).val();
     let directory = value.split("/")
     let title = directory.slice(-1)[0]
+    let validation = $(this).next();
 
     if (value == "" || !value.match(/[^\s\t]/)) {
-      $(this).next().text('タイトルを入力してください！');
+      validation.text('タイトルを入力してください！');
     } else if (title.length > 50 ) {
-      $(this).next().text('タイトルは50文字以内で入力してください！');
+      validation.text('タイトルは50文字以内で入力してください！');
       return false;
     } else if (directory.length > 6) {
-      $(this).next().text('ディレクトリは5つ以上作成できません！');
+      validation.text('ディレクトリは5つ以上作成できません！');
     } else {
-      $(this).next().text("");
+      validation.text("");
     }
 
     let result = false;
@@ -22,6 +23,6 @@ $(function() {
         return false;
       }
     });
-    if (result) { $(this).next().text('ディレクトリ名は20文字以内です'); }
+    if (result) { validation.text('ディレクトリ名は20文字以内です'); }
   });
 });

--- a/app/javascript/packs/documents/validation.js
+++ b/app/javascript/packs/documents/validation.js
@@ -1,9 +1,9 @@
 $(function() {
   $("#form-title").on("blur", function() {
-    let value = $(this).val();
-    let directory = value.split("/")
-    let title = directory.slice(-1)[0]
-    let validation = $(this).next();
+    const value = $(this).val();
+    const directory = value.split("/")
+    const title = directory.slice(-1)[0]
+    const validation = $(this).next();
 
     if (value == "" || !value.match(/[^\s\t]/)) {
       validation.text('タイトルを入力してください！');

--- a/app/javascript/packs/documents/validation.js
+++ b/app/javascript/packs/documents/validation.js
@@ -5,6 +5,7 @@ $(function() {
     const title = directory.slice(-1)[0]
     const validation = $("#title-error-message");
 
+    // HACK: switch文に変更予定
     if (value == "" || !value.match(/[^\s\t]/)) {
       validation.text('タイトルを入力してください！');
     } else if (title.length > 50 ) {

--- a/app/javascript/packs/documents/validation.js
+++ b/app/javascript/packs/documents/validation.js
@@ -1,5 +1,5 @@
 $(function() {
-  $(".form-title").on("blur", function() {
+  $("#form-title").on("blur", function() {
     let value = $(this).val();
     let directory = value.split("/")
     let title = directory.slice(-1)[0]

--- a/app/javascript/packs/documents/validation.js
+++ b/app/javascript/packs/documents/validation.js
@@ -1,16 +1,27 @@
 $(function() {
   $(".form-title").on("blur", function() {
-    let error;
     let value = $(this).val();
+    let directory = value.split("/")
+    let title = directory.slice(-1)[0]
 
     if (value == "" || !value.match(/[^\s\t]/)) {
-      error = true;
-    }
-
-    if (error) {
       $(this).next().text('タイトルを入力してください！');
+    } else if (title.length > 50 ) {
+      $(this).next().text('タイトルは50文字以内で入力してください！');
+      return false;
+    } else if (directory.length > 6) {
+      $(this).next().text('ディレクトリは5つ以上作成できません！');
     } else {
       $(this).next().text("");
     }
+
+    let result = false;
+    $.each(directory, function(index, value) {
+      if (value.length > 20) {
+        result = true;
+        return false;
+      }
+    });
+    if (result) { $(this).next().text('ディレクトリ名は20文字以内です'); }
   });
 });

--- a/app/javascript/packs/documents/validation.js
+++ b/app/javascript/packs/documents/validation.js
@@ -1,0 +1,16 @@
+$(function() {
+  $(".form-title").on("blur", function() {
+    let error;
+    let value = $(this).val();
+
+    if (value == "" || !value.match(/[^\s\t]/)) {
+      error = true;
+    }
+
+    if (error) {
+      $(this).next().text('タイトルを入力してください！');
+    } else {
+      $(this).next().text("");
+    }
+  });
+});

--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -3,10 +3,8 @@
     <div class="col-12">
       <div class='form-group mt-3 pr-3'>
         <%= f.label :タイトル %>
-        <%= f.text_field :title, class: 'form-control', value: value_text %>
-        <% if @error_messages.present? %>
-          <p style="color: red;"><%= @error_messages.first %></p>
-        <% end %>
+        <%= f.text_field :title, class: 'form-control form-title', value: value_text %>
+        <p style="color: red;"></p>
       </div>
     </div>
   </div>
@@ -30,3 +28,4 @@
     </div>
   </div>
 <% end %>
+<%= javascript_pack_tag 'documents/validation.js' %>

--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -3,7 +3,7 @@
     <div class="col-12">
       <div class='form-group mt-3 pr-3'>
         <%= f.label :タイトル %>
-        <%= f.text_field :title, class: 'form-control form-title', value: value_text %>
+        <%= f.text_field :title, class: 'form-control', id: 'form-title', value: value_text %>
         <p style="color: red;"></p>
       </div>
     </div>

--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -4,7 +4,7 @@
       <div class='form-group mt-3 pr-3'>
         <%= f.label :タイトル %>
         <%= f.text_field :title, class: 'form-control', id: 'form-title', value: value_text %>
-        <p style="color: red;"></p>
+        <p style="color: red;", id="title-error-message"></p>
       </div>
     </div>
   </div>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -7,11 +7,13 @@
       <h1 class="d-inline">
         <%= @document.title %>
       </h1>
-      <%= link_to edit_document_path, class: "text-decoration-none" do %>
-      <i class="fas fa-pen fa-2x pb-1 ml-2"></i>
-      <% end %>
-      <%= link_to document_path(@document), method: :delete, data: { confirm: "ドキュメントを削除してもよろしいですか？" } do %>
-      <i class="fas fa-trash-alt fa-2x pb-1 ml-2"></i>
+      <% if @document.writer_id == current_user.id %>
+        <%= link_to edit_document_path, class: "text-decoration-none" do %>
+          <i class="fas fa-pen fa-2x pb-1 ml-2"></i>
+        <% end %>
+          <%= link_to document_path(@document), method: :delete, data: { confirm: "ドキュメントを削除してもよろしいですか？" } do %>
+        <i class="fas fa-trash-alt fa-2x pb-1 ml-2"></i>
+        <% end %>
       <% end %>
     </div>
     <div class="col col-4 text-center">


### PR DESCRIPTION
## 概要
- 表題の通り


## タスク内容
- `validation.js` ファイルを作成してバリデーションエラーメッセージを設定
  - タイトル欄の入力値をチェックしてフォーカスが外れた際にメッセージが表示されるように設定
- 他ユーザーのドキュメント詳細画面では編集、削除ボタンが表示されないように設定

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub の Files changed で差分を確認
- [ ] 影響し得る範囲のローカル環境での動作確認


## 実装画面
![jQuery バリデーション](https://user-images.githubusercontent.com/67620156/120069734-5c520680-c0c2-11eb-9d42-56df99d56835.gif)


### その他
- jQueryを使用してタイトル欄の入力項目が正しくないと、作成ボタン押せないように設定予定です。
