### PR TITLE
バリデーションエラー時に submit しても画面遷移しないように実装

### DIFF
--- a/app/javascript/packs/documents/validation.js
+++ b/app/javascript/packs/documents/validation.js
@@ -17,9 +17,7 @@ $(function() {
 
     $.each(directory, (index, value) => { if(value.length > 20) { validation_msg.push('ディレクトリ名は20文字以内です') } });
 
-    $.each(validation_msg, function(index, value) {
-      validation.append(value + "<br>");
-    });
+    $.each(validation_msg, (index, value) => { validation.append(value + "<br>") });
   });
   $("#form-title").on("focus", function() {
     $("#title-error-message").empty();

--- a/app/javascript/packs/documents/validation.js
+++ b/app/javascript/packs/documents/validation.js
@@ -12,7 +12,7 @@ $(function() {
     if (value == "" || !value.match(/[^\s\t]/)) {
       validation_msg.push('タイトルを入力してください！');
     } else if (directory.length > 6) {
-      validation_msg.push('ディレクトリは5つ以上作成できません！');
+      validation_msg.push('ディレクトリは5つ以上作成できません！');
     } else if (title.length > 50 ) {
       validation_msg.push('タイトルは50文字以内で入力してください！');
     }

--- a/app/javascript/packs/documents/validation.js
+++ b/app/javascript/packs/documents/validation.js
@@ -1,9 +1,9 @@
 $(function() {
   $("#form-title").on("blur", function() {
     const value = $(this).val();
-    const directory = value.split("/")
-    const title = directory.slice(-1)[0]
-    const validation_msg = []
+    const directory = value.split("/");
+    const title = directory.slice(-1)[0];
+    const validation_msg = [];
     const validation = $("#title-error-message");
 
     // HACK: switch文に変更予定
@@ -15,7 +15,7 @@ $(function() {
       validation_msg.push('タイトルは50文字以内で入力してください！');
     }
 
-    $.each(directory, (index, value) => { if(value.length > 20) { validation_msg.push('ディレクトリ名は20文字以内です') } });
+    $.each(directory, (index, value) => { if(value.length > 20) { validation_msg.push('ディレクトリ名は20文字以内です'); return false; } });
 
     $.each(validation_msg, (index, value) => { validation.append(value + "<br>") });
   });

--- a/app/javascript/packs/documents/validation.js
+++ b/app/javascript/packs/documents/validation.js
@@ -1,6 +1,8 @@
 $(function() {
-  $("#form-title").on("blur", function() {
-    const value = $(this).val();
+  $("#form-title").on("blur", validation_check);
+  $("#form").on("submit", validation_check);
+  function validation_check() {
+    const value = $("#form-title").val();
     const directory = value.split("/");
     const title = directory.slice(-1)[0];
     const validation_msg = [];
@@ -17,9 +19,14 @@ $(function() {
 
     $.each(directory, (index, value) => { if(value.length > 20) { validation_msg.push('ディレクトリ名は20文字以内です'); return false; } });
 
-    $.each(validation_msg, (index, value) => { validation.append(value + "<br>") });
-  });
-  $("#form-title").on("focus", function() {
-    $("#title-error-message").empty();
-  });
+    const error = validation_msg.length;
+
+    if (error) {
+      validation.html( validation_msg.join('<br>') );
+      return false;
+    } else {
+      validation.html("");
+      return true;
+    }
+  }
 });

--- a/app/javascript/packs/documents/validation.js
+++ b/app/javascript/packs/documents/validation.js
@@ -17,10 +17,11 @@ $(function() {
 
     $.each(directory, (index, value) => { if(value.length > 20) { validation_msg.push('ディレクトリ名は20文字以内です') } });
 
-    if (validation_msg.length > 0) {
-      validation.text(validation_msg);
-    } else {
-      validation.text("");
-    }
+    $.each(validation_msg, function(index, value) {
+      validation.append(value + "<br>");
+    });
+  });
+  $("#form-title").on("focus", function() {
+    $("#title-error-message").empty();
   });
 });

--- a/app/javascript/packs/documents/validation.js
+++ b/app/javascript/packs/documents/validation.js
@@ -3,20 +3,24 @@ $(function() {
     const value = $(this).val();
     const directory = value.split("/")
     const title = directory.slice(-1)[0]
+    const validation_msg = []
     const validation = $("#title-error-message");
 
     // HACK: switch文に変更予定
     if (value == "" || !value.match(/[^\s\t]/)) {
-      validation.text('タイトルを入力してください！');
-    } else if (title.length > 50 ) {
-      validation.text('タイトルは50文字以内で入力してください！');
-      return false;
+      validation_msg.push('タイトルを入力してください！');
     } else if (directory.length > 6) {
-      validation.text('ディレクトリは5つ以上作成できません！');
+      validation_msg.push('ディレクトリは5つ以上作成できません！');
+    } else if (title.length > 50 ) {
+      validation_msg.push('タイトルは50文字以内で入力してください！');
+    }
+
+    $.each(directory, (index, value) => { if(value.length > 20) { validation_msg.push('ディレクトリ名は20文字以内です') } });
+
+    if (validation_msg.length > 0) {
+      validation.text(validation_msg);
     } else {
       validation.text("");
     }
-
-    $.each(directory, (index, value) => { if(value.length > 20) { validation.text('ディレクトリ名は20文字以内です') } });
   });
 });


### PR DESCRIPTION
## 概要
- 表題の通り


## タスク内容
- バリデーションエラーメッセージを配列に格納してまとめて表示
- submit 実行時にエラーがあれば画面遷移しないよう,submit イベントを追加

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub の Files changed で差分を確認
- [ ] 影響し得る範囲のローカル環境での動作確認


## 実装画面
- スクリーンショットなどを貼り付け
![スクリーンショット 2021-06-03 19 55 14](https://user-images.githubusercontent.com/67620156/120634572-5d11e080-c4a6-11eb-8b93-7bf963355ab1.png)


## その他参考情報
### 実装する上で参考にしたサイト
- [jQueryで入力チェック](https://qiita.com/ntm718/items/c1c105099783e09504f0)

