### PR TITLE
コミュニティ参加のバッチ処理を設定

### DIFF
--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -15,7 +15,8 @@ class CommunitiesController < ApplicationController
     @community = current_user.communities.new(community_create_params.merge(owner: current_user))
 
     if @community.valid?
-      current_user.communities.create!(community_create_params.merge(owner: current_user))
+      @community = current_user.communities.create!(community_create_params.merge(owner: current_user))
+      @community.slack_access_token.present? ? @community.slack_cooperation = true : @community.slack_cooperation = false
       flash[:primary] = "#{@community.name}コミュニティーを作成しました。"
       redirect_to communities_path
     else
@@ -26,7 +27,7 @@ class CommunitiesController < ApplicationController
   private
 
     def community_create_params
-      params.require(:community).permit(:name)
+      params.require(:community).permit(:name, :slack_access_token)
     end
 
     def authenticate_admin

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -11,7 +11,7 @@ class CommunitiesController < ApplicationController
     @communities = @communities.page(params[:page]).per(PER_PAGE)
   end
 
-  def create # rubocop:disable Metrics/AbcSize
+  def create
     @community = current_user.communities.new(community_create_params.merge(owner: current_user))
 
     if @community.valid?

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -17,6 +17,7 @@ class CommunitiesController < ApplicationController
     if @community.valid?
       @community = current_user.communities.create!(community_create_params.merge(owner: current_user))
       @community.slack_cooperation = (@community.slack_access_token.present? ? true : false)
+      @community.save!
       flash[:primary] = "#{@community.name}コミュニティーを作成しました。"
       redirect_to communities_path
     else

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -16,8 +16,6 @@ class CommunitiesController < ApplicationController
 
     if @community.valid?
       @community = current_user.communities.create!(community_create_params.merge(owner: current_user))
-      @community.slack_cooperation = (@community.slack_access_token.present? ? true : false)
-      @community.save!
       flash[:primary] = "#{@community.name}コミュニティーを作成しました。"
       redirect_to communities_path
     else

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -11,12 +11,12 @@ class CommunitiesController < ApplicationController
     @communities = @communities.page(params[:page]).per(PER_PAGE)
   end
 
-  def create
+  def create # rubocop:disable Metrics/AbcSize
     @community = current_user.communities.new(community_create_params.merge(owner: current_user))
 
     if @community.valid?
       @community = current_user.communities.create!(community_create_params.merge(owner: current_user))
-      @community.slack_access_token.present? ? @community.slack_cooperation = true : @community.slack_cooperation = false
+      @community.slack_cooperation = (@community.slack_access_token.present? ? true : false)
       flash[:primary] = "#{@community.name}コミュニティーを作成しました。"
       redirect_to communities_path
     else

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -5,7 +5,6 @@
 #  id                 :bigint           not null, primary key
 #  name               :string           not null
 #  slack_access_token :string
-#  slack_cooperation  :boolean          default(FALSE), not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  owner_id           :bigint

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -2,11 +2,13 @@
 #
 # Table name: communities
 #
-#  id         :bigint           not null, primary key
-#  name       :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  owner_id   :bigint
+#  id                 :bigint           not null, primary key
+#  name               :string           not null
+#  slack_access_token :string
+#  slack_cooperation  :boolean          default(FALSE), not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  owner_id           :bigint
 #
 # Indexes
 #

--- a/app/views/communities/_form.html.erb
+++ b/app/views/communities/_form.html.erb
@@ -1,14 +1,17 @@
 <%= form_with model:community, local: true, id: "form" do |f| %>
-<div class="row">
-  <div class="col-6">
-    <div class='form-group mt-3 pr-3'>
-      <%= f.label :コミュニティー作成 %>
-      <%= f.text_field :name, class: 'form-control', id: 'form-title', value: value_text, placeholder: 'コミュニティーをつくろう!' %>
-      <%= render partial: 'validation', locals: { community: @community } %>
-    </div>
-  </div>
-  <div class="mt-5 pr-3">
-    <%= f.submit "作成", class: 'btn btn-primary create_docuent_button' %>
-  </div>
+
+<h4 class="mt-4">コミュニティ作成</h4>
+
+<div class='form-group mt-3 pr-3'>
+  <%= f.label :名前 %>
+  <%= f.text_field :name, class: 'form-control', id: 'form-title', value: value_text, placeholder: 'コミュニティーをつくろう!' %>
+  <%= render partial: 'validation', locals: { community: @community } %>
+</div>
+<div class='form-group mt-3 pr-3'>
+  <%= f.label :"slack アクセストークン" %>
+  <%= f.text_field :slack_access_token, class: 'form-control', id: 'form-title', value: value_text, placeholder: 'アクセストークン' %>
+</div>
+<div class="mt-5 pr-3">
+  <%= f.submit "作成", class: 'btn btn-primary create_docuent_button' %>
 </div>
 <% end %>

--- a/config/initializers/slack_ruby_client.rb
+++ b/config/initializers/slack_ruby_client.rb
@@ -1,3 +1,0 @@
-Slack.configure do |config|
-  config.token = ENV["ACCESS_TOKEN"]
-end

--- a/db/migrate/20210615151654_add_columns_to_communities.rb
+++ b/db/migrate/20210615151654_add_columns_to_communities.rb
@@ -2,7 +2,6 @@ class AddColumnsToCommunities < ActiveRecord::Migration[6.1]
   def change
     change_table :communities, bulk: true do |t|
       t.string :slack_access_token
-      t.boolean :slack_cooperation, default: false, null: false
     end
   end
 end

--- a/db/migrate/20210615151654_add_columns_to_communities.rb
+++ b/db/migrate/20210615151654_add_columns_to_communities.rb
@@ -1,6 +1,8 @@
 class AddColumnsToCommunities < ActiveRecord::Migration[6.1]
   def change
-    add_column :communities, :slack_access_token, :string
-    add_column :communities, :slack_cooperation, :boolean, default: false, null: false
+    change_table :communities, bulk: true do |t|
+      t.string :slack_access_token
+      t.boolean :slack_cooperation, default: false, null: false
+    end
   end
 end

--- a/db/migrate/20210615151654_add_columns_to_communities.rb
+++ b/db/migrate/20210615151654_add_columns_to_communities.rb
@@ -1,0 +1,6 @@
+class AddColumnsToCommunities < ActiveRecord::Migration[6.1]
+  def change
+    add_column :communities, :slack_access_token, :string
+    add_column :communities, :slack_cooperation, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_15_124426) do
+ActiveRecord::Schema.define(version: 2021_06_15_151654) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,6 +30,8 @@ ActiveRecord::Schema.define(version: 2021_06_15_124426) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "owner_id"
+    t.string "slack_access_token"
+    t.boolean "slack_cooperation", default: false, null: false
     t.index ["name"], name: "index_communities_on_name", unique: true
     t.index ["owner_id"], name: "index_communities_on_owner_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,7 +31,6 @@ ActiveRecord::Schema.define(version: 2021_06_15_151654) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "owner_id"
     t.string "slack_access_token"
-    t.boolean "slack_cooperation", default: false, null: false
     t.index ["name"], name: "index_communities_on_name", unique: true
     t.index ["owner_id"], name: "index_communities_on_owner_id"
   end

--- a/lib/tasks/slack_search.rake
+++ b/lib/tasks/slack_search.rake
@@ -2,7 +2,7 @@ namespace :slack_search do
   desc "search_users"
   task search_users: :environment do
     client = Slack::Web::Client.new
-    client.token = ENV['ACCESSTOKEN']
+    client.token = ENV["ACCESSTOKEN"]
     user_emails = User.pluck(:email)
     all_members_data = client.users_list[:members]
     all_members_data.each do |member_data|

--- a/lib/tasks/slack_search.rake
+++ b/lib/tasks/slack_search.rake
@@ -19,7 +19,7 @@ namespace :slack_search do
       client = Slack::Web::Client.new
       communities = Community.where(slack_cooperation: true)
       communities.each do |community|
-        next unless community.slack_access_token.present?
+        next if community.slack_access_token.blank?
 
         client.token = community.slack_access_token
         joined_user_emails = community.users.pluck(:email)
@@ -29,7 +29,7 @@ namespace :slack_search do
         delete_user_emails = joined_user_emails - all_members_emails
         existed_users = community.users.where(email: add_user_emails)
         add_user_emails.each do |email|
-          user = existed_users.find { |user| user.email == email }
+          user = existed_users.find {|existed_user| existed_user.email == email }
           community.community_users.create!(user: user)
         end
         delete_user_emails.each do |email|

--- a/lib/tasks/slack_search.rake
+++ b/lib/tasks/slack_search.rake
@@ -15,12 +15,24 @@ namespace :slack_search do
 
   desc "slack に登録しているユーザーについてコミュニティに自動で参加する機能"
   task join_community: :environment do
-    client = Slack::Web::Client.new
-    community = Community.first
-    joined_user_emails = community.users.pluck(:email)
-    all_members_data = client.users_list[:members]
-    all_members_emails = all_members_data.map {|member_data| member_data[:profile][:email] }.compact
-    target_user_emails = all_members_emails.difference(joined_user_emails)
-    target_user_emails.each {|target_user_email| community.users << User.find_by(email: target_user_email) }
+    ActiveRecord::Base.transaction do
+      client = Slack::Web::Client.new
+      community = Community.first
+      joined_user_emails = community.users.pluck(:email)
+      all_members_data = client.users_list[:members]
+      all_members_emails = all_members_data.map {|member_data| member_data[:profile][:email] }.compact
+      add_user_emails = all_members_emails - joined_user_emails
+      delete_user_emails = joined_user_emails - all_members_emails
+      existed_users = community.users.where(email: add_user_emails)
+      add_user_emails.each do |email|
+        user = existed_users.find { |user| user.email == email }
+        community.community_users.create!(user: user)
+      end
+      delete_user_emails.each do |email|
+        target_user = User.find_by(email: email)
+        community_user = target_user.community_users.find_by(community: community)
+        community_user.destroy!
+      end
+    end
   end
 end

--- a/lib/tasks/slack_search.rake
+++ b/lib/tasks/slack_search.rake
@@ -2,14 +2,19 @@ namespace :slack_search do
   desc "search_users"
   task search_users: :environment do
     client = Slack::Web::Client.new
-    client.token = ENV["ACCESSTOKEN"]
     user_emails = User.pluck(:email)
-    all_members_data = client.users_list[:members]
-    all_members_data.each do |member_data|
-      next if member_data[:profile][:email].nil?
+    communities = Community.where(slack_cooperation: true)
+    communities.each do |community|
+      next if community.slack_access_token.blank?
 
-      unless user_emails.include?(member_data[:profile][:email])
-        User.create!(name: member_data[:profile][:real_name], email: member_data[:profile][:email])
+      client.token = community.slack_access_token
+      all_members_data = client.users_list[:members]
+      all_members_data.each do |member_data|
+        next if member_data[:profile][:email].nil?
+
+        unless user_emails.include?(member_data[:profile][:email])
+          User.create!(name: member_data[:profile][:real_name], email: member_data[:profile][:email])
+        end
       end
     end
   end

--- a/lib/tasks/slack_search.rake
+++ b/lib/tasks/slack_search.rake
@@ -33,7 +33,7 @@ namespace :slack_search do
         all_members_emails = all_members_data.map {|member_data| member_data[:profile][:email] }.compact
         add_user_emails = all_members_emails - joined_user_emails
         delete_user_emails = joined_user_emails - all_members_emails
-        existed_users = community.users.where(email: add_user_emails)
+        existed_users = User.where(email: add_user_emails)
         add_user_emails.each do |email|
           user = existed_users.find {|existed_user| existed_user.email == email }
           community.community_users.create!(user: user)

--- a/lib/tasks/slack_search.rake
+++ b/lib/tasks/slack_search.rake
@@ -12,4 +12,19 @@ namespace :slack_search do
       end
     end
   end
+
+  desc "slack に登録しているユーザーについてコミュニティに自動で参加する機能"
+  task join_community: :environment do
+    client = Slack::Web::Client.new
+    community = Community.first
+    target_users_email = community.users.pluck(:email)
+    all_members_data = client.users_list[:members]
+    all_members_data.each do |member_data|
+      next if member_data[:profile][:email].nil?
+
+      unless target_users_email.include?(member_data[:profile][:email])
+        community.users << User.find_by(email: member_data[:profile][:email])
+      end
+    end
+  end
 end

--- a/lib/tasks/slack_search.rake
+++ b/lib/tasks/slack_search.rake
@@ -3,7 +3,7 @@ namespace :slack_search do
   task search_users: :environment do
     client = Slack::Web::Client.new
     user_emails = User.pluck(:email)
-    communities = Community.where(slack_cooperation: true)
+    communities = Community.all
     communities.each do |community|
       next if community.slack_access_token.blank?
 
@@ -23,7 +23,7 @@ namespace :slack_search do
   task join_community: :environment do
     ActiveRecord::Base.transaction do
       client = Slack::Web::Client.new
-      communities = Community.where(slack_cooperation: true)
+      communities = Community.all
       communities.each do |community|
         next if community.slack_access_token.blank?
 

--- a/lib/tasks/slack_search.rake
+++ b/lib/tasks/slack_search.rake
@@ -17,14 +17,10 @@ namespace :slack_search do
   task join_community: :environment do
     client = Slack::Web::Client.new
     community = Community.first
-    target_users_email = community.users.pluck(:email)
+    joined_user_emails = community.users.pluck(:email)
     all_members_data = client.users_list[:members]
-    all_members_data.each do |member_data|
-      next if member_data[:profile][:email].nil?
-
-      unless target_users_email.include?(member_data[:profile][:email])
-        community.users << User.find_by(email: member_data[:profile][:email])
-      end
-    end
+    all_members_emails = all_members_data.map {|member_data| member_data[:profile][:email] }.compact
+    target_user_emails = all_members_emails.difference(joined_user_emails)
+    target_user_emails.each {|target_user_email| community.users << User.find_by(email: target_user_email) }
   end
 end

--- a/lib/tasks/slack_search.rake
+++ b/lib/tasks/slack_search.rake
@@ -2,6 +2,7 @@ namespace :slack_search do
   desc "search_users"
   task search_users: :environment do
     client = Slack::Web::Client.new
+    client.token = ENV['ACCESSTOKEN']
     user_emails = User.pluck(:email)
     all_members_data = client.users_list[:members]
     all_members_data.each do |member_data|

--- a/spec/factories/communities.rb
+++ b/spec/factories/communities.rb
@@ -5,7 +5,6 @@
 #  id                 :bigint           not null, primary key
 #  name               :string           not null
 #  slack_access_token :string
-#  slack_cooperation  :boolean          default(FALSE), not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  owner_id           :bigint

--- a/spec/factories/communities.rb
+++ b/spec/factories/communities.rb
@@ -2,11 +2,13 @@
 #
 # Table name: communities
 #
-#  id         :bigint           not null, primary key
-#  name       :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  owner_id   :bigint
+#  id                 :bigint           not null, primary key
+#  name               :string           not null
+#  slack_access_token :string
+#  slack_cooperation  :boolean          default(FALSE), not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  owner_id           :bigint
 #
 # Indexes
 #

--- a/spec/lib/tasks/slack_search_spec.rb
+++ b/spec/lib/tasks/slack_search_spec.rb
@@ -4,8 +4,34 @@ describe "slack_search" do # rubocop:disable RSpec/DescribeClass
   let(:task1) { Rake.application["slack_search:search_users"] }
   let(:task2) { Rake.application["slack_search:join_community"] }
 
-  it "slack 連携のバッチ処理が実行される" do
-    expect(task1.invoke).to be_truthy
-    expect(task2.invoke).to be_truthy
+  let(:users_list_mock) { { members: [ { profile: { email: "sample1@example.com", real_name: "sample1" } },
+                                       { profile: { email: "sample2@example.com", real_name: "sample2" } },
+                                       { profile: { email: "sample@example.com", real_name: "t-ehara" } }
+  ] } }
+
+  before { allow_any_instance_of(Slack::Web::Client).to receive(:users_list).and_return(users_list_mock) }
+
+  context "コミュニティと slack が連携している時" do
+    let(:user) { create(:user, name: "t-ehara", email: "sample@example.com") }
+    let!(:community) { create(:community, owner: user, slack_access_token: "xoxp-abcdefghijklmn123456789")}
+    it "バッチ処理が実行される" do
+      user.have_communities.first.community_users.create!(user: user)
+      expect{ task1.execute }.to change{ User.count }.from(1).to(3)
+      expect(task1.execute).to be_truthy
+      expect{ task2.execute }.to change{ community.users.count }.from(1).to(3)
+      expect(task2.execute).to be_truthy
+    end
+  end
+
+  context "コミュニティがslack 連携をしていない時" do
+    let(:user) { create(:user, name: "t-ehara", email: "sample@example.com") }
+    let!(:community) { create(:community, owner: user, slack_access_token: nil) }
+    it "バッチ処理はスキップされる" do
+      user.have_communities.first.community_users.create!(user: user)
+      expect{ task1.execute }.not_to change{ User.count }
+      expect(task1.execute).to be_truthy
+      expect{ task2.execute }.not_to change{ community.users.count }
+      expect(task2.execute).to be_truthy
+    end
   end
 end

--- a/spec/lib/tasks/slack_search_spec.rb
+++ b/spec/lib/tasks/slack_search_spec.rb
@@ -1,0 +1,39 @@
+# require 'rake_helper'
+
+
+# describe 'slack_search' do
+#   subject(:task) { Rake.application['slack_search'] }
+
+#   it 'slack 連携のバッチ処理が実行される' do
+#     binding.pry
+#     expect { task.invoke }.to be_truthy
+#   end
+# end
+require 'rails_helper'
+require 'rake'
+
+describe 'rake task slack_search' do
+  before(:all) do
+    @rake = Rake::Application.new
+    Rake.application = @rake
+    Rake.application.rake_require 'tasks/slack_search' # Point 1
+    Rake::Task.define_task(:environment)
+  end
+
+  before(:each) do
+    @rake[task].reenable  # Point 2
+  end
+
+  describe 'slack_search:search_users' do
+    let(:task) { 'slack_search:search_users' }
+    it 'slack と連携したユーザー登録' do
+      expect(@rake[task].invoke).to be_truthy
+    end
+  end
+  describe 'slack_search:join_community' do
+    let(:task) { 'slack_search:join_community' }
+    it 'slack と連携したコミュニティ参加機能' do
+      expect(@rake[task].invoke).to be_truthy
+    end
+  end
+end

--- a/spec/lib/tasks/slack_search_spec.rb
+++ b/spec/lib/tasks/slack_search_spec.rb
@@ -1,39 +1,11 @@
-# require 'rake_helper'
+require "rake_helper"
 
+describe "slack_search" do # rubocop:disable RSpec/DescribeClass
+  let(:task1) { Rake.application["slack_search:search_users"] }
+  let(:task2) { Rake.application["slack_search:join_community"] }
 
-# describe 'slack_search' do
-#   subject(:task) { Rake.application['slack_search'] }
-
-#   it 'slack 連携のバッチ処理が実行される' do
-#     binding.pry
-#     expect { task.invoke }.to be_truthy
-#   end
-# end
-require 'rails_helper'
-require 'rake'
-
-describe 'rake task slack_search' do
-  before(:all) do
-    @rake = Rake::Application.new
-    Rake.application = @rake
-    Rake.application.rake_require 'tasks/slack_search' # Point 1
-    Rake::Task.define_task(:environment)
-  end
-
-  before(:each) do
-    @rake[task].reenable  # Point 2
-  end
-
-  describe 'slack_search:search_users' do
-    let(:task) { 'slack_search:search_users' }
-    it 'slack と連携したユーザー登録' do
-      expect(@rake[task].invoke).to be_truthy
-    end
-  end
-  describe 'slack_search:join_community' do
-    let(:task) { 'slack_search:join_community' }
-    it 'slack と連携したコミュニティ参加機能' do
-      expect(@rake[task].invoke).to be_truthy
-    end
+  it "slack 連携のバッチ処理が実行される" do
+    expect(task1.invoke).to be_truthy
+    expect(task2.invoke).to be_truthy
   end
 end

--- a/spec/lib/tasks/slack_search_spec.rb
+++ b/spec/lib/tasks/slack_search_spec.rb
@@ -11,15 +11,15 @@ describe "slack_search" do # rubocop:disable RSpec/DescribeClass
   }
 
   before {
-    client_mock = instance_double("Client")
+    client_mock = instance_double("Slack Client")
+    allow(client_mock).to receive(:token=)
     allow(client_mock).to receive(:users_list).and_return(users_list_mock)
-    slack_web_client = Slack::Web::Client.new
-    allow(slack_web_client).to receive(:client).and_return(client_mock)
+    allow(Slack::Web::Client).to receive(:new).and_return(client_mock)
   }
 
   context "コミュニティと slack が連携している時" do # rubocop:disable RSpec/MultipleMemoizedHelpers
     let(:user) { create(:user, name: "t-ehara", email: "sample@example.com") }
-    let(:community) { create(:community, owner: user, slack_access_token: "xoxp-abcdefghijklmn123456789") }
+    let(:community) { create(:community, owner: user, slack_access_token: "SLACK-ACCESS-TOKEN") }
     let!(:community_user) { create(:community_user, user: user, community: community) }
     it "バッチ処理が実行される" do
       expect { task1.execute }.to change { User.count }.from(1).to(3)

--- a/spec/lib/tasks/slack_search_spec.rb
+++ b/spec/lib/tasks/slack_search_spec.rb
@@ -4,21 +4,22 @@ describe "slack_search" do # rubocop:disable RSpec/DescribeClass
   let(:task1) { Rake.application["slack_search:search_users"] }
   let(:task2) { Rake.application["slack_search:join_community"] }
 
-  let(:users_list_mock) { { members: [ { profile: { email: "sample1@example.com", real_name: "sample1" } },
-                                       { profile: { email: "sample2@example.com", real_name: "sample2" } },
-                                       { profile: { email: "sample@example.com", real_name: "t-ehara" } }
-  ] } }
+  let(:users_list_mock) {
+    { members: [{ profile: { email: "sample1@example.com", real_name: "sample1" } },
+                { profile: { email: "sample2@example.com", real_name: "sample2" } },
+                { profile: { email: "sample@example.com", real_name: "t-ehara" } }] }
+  }
 
-  before { allow_any_instance_of(Slack::Web::Client).to receive(:users_list).and_return(users_list_mock) }
+  before { allow_any_instance_of(Slack::Web::Client).to receive(:users_list).and_return(users_list_mock) } # rubocop:disable RSpec/AnyInstance
 
   context "コミュニティと slack が連携している時" do
     let(:user) { create(:user, name: "t-ehara", email: "sample@example.com") }
-    let!(:community) { create(:community, owner: user, slack_access_token: "xoxp-abcdefghijklmn123456789")}
+    let!(:community) { create(:community, owner: user, slack_access_token: "xoxp-abcdefghijklmn123456789") }
     it "バッチ処理が実行される" do
       user.have_communities.first.community_users.create!(user: user)
-      expect{ task1.execute }.to change{ User.count }.from(1).to(3)
+      expect { task1.execute }.to change { User.count }.from(1).to(3)
       expect(task1.execute).to be_truthy
-      expect{ task2.execute }.to change{ community.users.count }.from(1).to(3)
+      expect { task2.execute }.to change { community.users.count }.from(1).to(3)
       expect(task2.execute).to be_truthy
     end
   end
@@ -28,9 +29,9 @@ describe "slack_search" do # rubocop:disable RSpec/DescribeClass
     let!(:community) { create(:community, owner: user, slack_access_token: nil) }
     it "バッチ処理はスキップされる" do
       user.have_communities.first.community_users.create!(user: user)
-      expect{ task1.execute }.not_to change{ User.count }
+      expect { task1.execute }.not_to change { User.count }
       expect(task1.execute).to be_truthy
-      expect{ task2.execute }.not_to change{ community.users.count }
+      expect { task2.execute }.not_to change { community.users.count }
       expect(task2.execute).to be_truthy
     end
   end

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -5,7 +5,6 @@
 #  id                 :bigint           not null, primary key
 #  name               :string           not null
 #  slack_access_token :string
-#  slack_cooperation  :boolean          default(FALSE), not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  owner_id           :bigint

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -2,11 +2,13 @@
 #
 # Table name: communities
 #
-#  id         :bigint           not null, primary key
-#  name       :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  owner_id   :bigint
+#  id                 :bigint           not null, primary key
+#  name               :string           not null
+#  slack_access_token :string
+#  slack_cooperation  :boolean          default(FALSE), not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  owner_id           :bigint
 #
 # Indexes
 #

--- a/spec/rake_helper.rb
+++ b/spec/rake_helper.rb
@@ -1,0 +1,10 @@
+require "rake"
+RSpec.configure do |config|
+  config.before(:suite) do
+    Rails.application.load_tasks # Load all the tasks just as Rails does (`load 'Rakefile'` is another simple way)
+  end
+
+  config.before do
+    Rake.application.tasks.each(&:reenable) # Remove persistency between examples
+  end
+end


### PR DESCRIPTION
## 概要
- 表題の通り


## タスク内容
- 連携しているslack のユーザーを取得し、特定のコミュニティに参加する処理を実装

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub の Files changed で差分を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## その他参考情報

- コミュニティについてはひとまずワンダフルコードのコミュニティのみで運用するとのことなので、`Community.first`で取り出しています。（このバッチ処理はコミュニティが一つしかない場合のみ採用する想定です）