### PR TITLE
ドラッグ＆ドロップのUI修正＋テキストエリア以外でドロップした場合の画面遷移防止の実装

### DIFF
--- a/app/javascript/packs/documents/fileupload.js
+++ b/app/javascript/packs/documents/fileupload.js
@@ -1,10 +1,11 @@
 $(function() {
   $('#markdown_editor_textarea').on('drop', function(e) {
+    $('#markdown_editor_textarea').css('border', '1px solid #d6dde4');
     e.preventDefault();
     f = e.originalEvent.dataTransfer.files[0];
     const imageData = $('#image').prop('files', f);
     const formData = new FormData();
-    formData.append("image", f);
+    formData.append('image', f);
 
     $.ajax({
       url: "/document_images",
@@ -22,4 +23,30 @@ $(function() {
       $("#markdown_preview").html(html);
     });
   });
+     // ドラッグしている要素がドロップ領域に入ったとき・領域にある間
+  $('#markdown_editor_textarea').on('dragenter dragover', function (e) {
+    e.stopPropagation();
+    e.preventDefault();
+    $('#markdown_editor_textarea').css('border', '1px solid #333');
+  });
+
+    // ドラッグしている要素がドロップ領域から外れたとき
+  $('#markdown_editor_textarea').on('dragleave', function (e) {
+    e.stopPropagation();
+    e.preventDefault();
+    $('#markdown_editor_textarea').css('border', '1px solid #d6dde4');
+  });
+    // markdown_editor_textarea以外でファイルがドロップされた場合、ファイルが開いてしまうのを防ぐ
+  window.ondrop = function(e){
+    e.preventDefault();　//動作する
+    };
+
+  window.ondragleave = function(e){
+    e.stopPropagation();
+    e.preventDefault();
+  };
+
+  window.ondragover = function(e){
+    e.preventDefault();　//動作する
+    };
 });

--- a/app/javascript/packs/documents/fileupload.js
+++ b/app/javascript/packs/documents/fileupload.js
@@ -15,7 +15,6 @@ $(function() {
     }).done((data) => {
       const url = data.url;
       const filename = data.filename;
-
       const textArea = document.getElementById("markdown_editor_textarea");
       const fileLink = `![${filename}](${url})`;
       textArea.value = `${textArea.value}\n${fileLink}`;

--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -14,10 +14,6 @@
         <%= f.label :本文 %>
         <%= f.text_area :body, rows: 10, class: 'form-control input_body', id: 'markdown_editor_textarea', placeholder: '本文を書いていきましょう' %>
       </div>
-      <div class='form-group'>
-        <%= f.label :画像を添付 %>
-        <%= f.file_field :image, multiple: true, id: 'image' %>
-      </div>
       <div class="text-right">
         <%= f.submit class: 'btn btn-primary create_docuent_button' %>
       </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -61,9 +61,9 @@ if User.all.blank?
     ##########################################
     # Communityの作成
     ##########################################
-    community = Community.create!(name: "Wonderful-Portal")
-    community2 = Community.create!(name: "Wonderful-Code")
-    Community.create!(name: "Wonderfur-Editor")
+    community = Community.create!(name: "Wonderful-Portal", owner: user)
+    community2 = Community.create!(name: "Wonderful-Code", owner: user)
+    Community.create!(name: "Wonderfur-Editor", owner: user)
 
     ##########################################
     # CommunityUserの作成


### PR DESCRIPTION
## 概要
- 表題の通り


## タスク内容
- 表題の通り

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub の Files changed で差分を確認
- [x] 影響し得る範囲のローカル環境での動作確認


## 実装画面
- スクリーンショットなどを貼り付け
![UI修正](https://user-images.githubusercontent.com/74192752/121783216-4c6d1300-cbe8-11eb-95ec-bdcb56de8a22.gif)

## その他参考情報
### 実装する上で参考にしたサイト
- [beforeunloadについて](https://html.spec.whatwg.org/multipage/browsing-the-web.html#beforeunloadevent)
- [画像遷移について](https://teratail.com/questions/97734)
- [UI改善について](https://qiita.com/masopoloiso/items/bdd9e0061ed37acb010d)

