### PR TITLE
コミュニティ作成機能の実装

### DIFF
--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,5 +1,5 @@
 class CommunitiesController < ApplicationController
-  before_action :user_admin?, only: [:new]
+  before_action :authenticate_admin, only: [:new, :create]
   PER_PAGE = 10
 
   def new
@@ -12,10 +12,10 @@ class CommunitiesController < ApplicationController
   end
 
   def create
-    @community = current_user.communities.new(community_create_params)
+    @community = current_user.communities.new(community_create_params.merge(owner: current_user))
 
     if @community.valid?
-      current_user.communities.create!(community_create_params)
+      current_user.communities.create!(community_create_params.merge(owner: current_user))
       flash[:primary] = "#{@community.name}コミュニティーを作成しました。"
       redirect_to communities_path
     else
@@ -27,10 +27,10 @@ class CommunitiesController < ApplicationController
   private
 
     def community_create_params
-      params.require(:community).permit(:name).merge(owner: current_user)
+      params.require(:community).permit(:name)
     end
 
-    def user_admin?
+    def authenticate_admin
       redirect_to communities_path unless current_user.admin?
     end
 end

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -11,10 +11,21 @@ class CommunitiesController < ApplicationController
   end
 
   def create
-    # FIXME: 重複コミュニティバリエーション or "既に存在するコミュニティ名です" の文言
-    @community = current_user.communities.create!(name: params[:community][:name], owner: current_user)
+    community_name = params[:community][:name]
 
-    flash[:success] = "#{@community.name}コミュニティーを作成しました。"
+    if community_name.empty?
+      flash[:danger] = "入力されていません。"
+      return redirect_back(fallback_location: root_path)
+    end
+
+    unless Community.find_by(name: community_name)
+      @community = current_user.communities.create!(name: community_name, owner: current_user)
+      flash[:primary] = "#{@community.name}コミュニティーを作成しました。"
+
+      return redirect_back(fallback_location: root_path)
+    end
+
+    flash[:warning] = "#{community_name}コミュニティーは既に作成されています。"
     redirect_back(fallback_location: root_path)
   end
 end

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -12,10 +12,10 @@ class CommunitiesController < ApplicationController
   end
 
   def create
-    @community = current_user.communities.new(name: community_create_params, owner: current_user)
+    @community = current_user.communities.new(community_create_params)
 
     if @community.valid?
-      current_user.communities.create!(name: community_create_params, owner: current_user)
+      current_user.communities.create!(community_create_params)
       flash[:primary] = "#{@community.name}コミュニティーを作成しました。"
       redirect_to communities_path
     else
@@ -27,11 +27,10 @@ class CommunitiesController < ApplicationController
   private
 
     def community_create_params
-      params.require(:community).permit(:name).values[0]
+      params.require(:community).permit(:name).merge(owner: current_user)
     end
 
     def user_admin
-      @users = User.all
       if current_user.admin == false
         redirect_to communities_path
       else

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -5,4 +5,11 @@ class CommunitiesController < ApplicationController
     @communities = current_user.communities
     @communities = @communities.page(params[:page]).per(PER_PAGE)
   end
+
+  def create
+    @community = current_user.communities.create!(name: params[:name], owner: current_user)
+
+    flash[:success] = "#{@community.name}コミュニティーを作成しました。"
+    redirect_back(fallback_location: root_path)
+  end
 end

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -12,7 +12,7 @@ class CommunitiesController < ApplicationController
 
   def create
     # FIXME: 重複コミュニティバリエーション or "既に存在するコミュニティ名です" の文言
-    @community = current_user.communities.create!(name: params[:name], owner: current_user)
+    @community = current_user.communities.create!(name: params[:community][:name], owner: current_user)
 
     flash[:success] = "#{@community.name}コミュニティーを作成しました。"
     redirect_back(fallback_location: root_path)

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -2,7 +2,7 @@ class CommunitiesController < ApplicationController
   PER_PAGE = 10
 
   def new
-    # TODO: コミュニティ管理画面
+    @community = current_user.communities.new
   end
 
   def index

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,12 +1,17 @@
 class CommunitiesController < ApplicationController
   PER_PAGE = 10
 
+  def new
+    # TODO: コミュニティ管理画面
+  end
+
   def index
     @communities = current_user.communities
     @communities = @communities.page(params[:page]).per(PER_PAGE)
   end
 
   def create
+    # FIXME: 重複コミュニティバリエーション or "既に存在するコミュニティ名です" の文言
     @community = current_user.communities.create!(name: params[:name], owner: current_user)
 
     flash[:success] = "#{@community.name}コミュニティーを作成しました。"

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,5 +1,5 @@
 class CommunitiesController < ApplicationController
-  before_action :is_user_admin, only: [:new]
+  before_action :user_admin?, only: [:new]
   PER_PAGE = 10
 
   def new
@@ -30,7 +30,7 @@ class CommunitiesController < ApplicationController
       params.require(:community).permit(:name).merge(owner: current_user)
     end
 
-    def is_user_admin
+    def user_admin?
       redirect_to communities_path unless current_user.admin?
     end
 end

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,5 +1,5 @@
 class CommunitiesController < ApplicationController
-  before_action :user_admin, only: [:new]
+  before_action :is_user_admin, only: [:new]
   PER_PAGE = 10
 
   def new
@@ -30,11 +30,7 @@ class CommunitiesController < ApplicationController
       params.require(:community).permit(:name).merge(owner: current_user)
     end
 
-    def user_admin
-      if current_user.admin == false
-        redirect_to communities_path
-      else
-        render action: "new"
-      end
+    def is_user_admin
+      redirect_to communities_path unless current_user.admin?
     end
 end

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -10,22 +10,76 @@ class CommunitiesController < ApplicationController
     @communities = @communities.page(params[:page]).per(PER_PAGE)
   end
 
+  # be rails generate scaffold community
+  # POST /communities or /communities.json
+  # def create
+  # # binding.pry
+  #   @community = Community.new(community_params)
+
+  #   if @community.save
+  #     redirect_to @community, notice: "Community was successfully created."
+  #   else
+  #     render :new
+  #   end
+  # end
+
+  # strong_params 使う
+
+  # uniqeness
+
   def create
-    community_name = params[:community][:name]
+    @community = current_user.communities.new(name: params[:community][:name], owner: current_user)
 
-    if community_name.empty?
-      flash[:danger] = "入力されていません。"
-      return redirect_back(fallback_location: root_path)
-    end
-
-    unless Community.find_by(name: community_name)
-      @community = current_user.communities.create!(name: community_name, owner: current_user)
+    # バリテーションのチェック ここだけ
+    # 次に処理
+    # DBに登録する処理 > SQL : 成功してる
+    if @community.save
+      binding.pry
       flash[:primary] = "#{@community.name}コミュニティーを作成しました。"
-
-      return redirect_back(fallback_location: root_path)
+      redirect_to communities_path
+    else
+      render :new
     end
-
-    flash[:warning] = "#{community_name}コミュニティーは既に作成されています。"
-    redirect_back(fallback_location: root_path)
   end
+
+  # 違い：
+  # - redirect_to: 全部データが消える。　router  を見に行く
+
+  # - render は flash は使えない?? なぜ flash.now[:]
+
+
+  # - render : 再描写され、new を描写しろよ!
+
+
+  # 保留
+  # def create
+  #   community_name = params[:community][:name]
+
+  #   if community_name.empty?
+  #     flash[:danger] = "入力されていません。"
+  #     return redirect_back(fallback_location: root_path)
+  #   end
+
+  #   unless Community.find_by(name: community_name)
+  #     @community = current_user.communities.create!(name: community_name, owner: current_user)
+  #     flash[:primary] = "#{community_name}コミュニティーを作成しました。"
+
+  #     return redirect_back(fallback_location: root_path)
+  #   end
+
+  #   flash[:warning] = "#{community_name}コミュニティーは既に作成されています。"
+  #   redirect_back(fallback_location: root_path)
+  # end
+
+  # private
+
+  #   # Use callbacks to share common setup or constraints between actions.
+  #   def set_community
+  #     @community = Community.find(params[:id])
+  #   end
+
+  #   # Only allow a list of trusted parameters through.
+  #   def community_params
+  #     params.fetch(:community, {})
+  #   end
 end

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -10,76 +10,22 @@ class CommunitiesController < ApplicationController
     @communities = @communities.page(params[:page]).per(PER_PAGE)
   end
 
-  # be rails generate scaffold community
-  # POST /communities or /communities.json
-  # def create
-  # # binding.pry
-  #   @community = Community.new(community_params)
-
-  #   if @community.save
-  #     redirect_to @community, notice: "Community was successfully created."
-  #   else
-  #     render :new
-  #   end
-  # end
-
-  # strong_params 使う
-
-  # uniqeness
-
   def create
-    @community = current_user.communities.new(name: params[:community][:name], owner: current_user)
+    @community = current_user.communities.new(name: community_create_params, owner: current_user)
 
-    # バリテーションのチェック ここだけ
-    # 次に処理
-    # DBに登録する処理 > SQL : 成功してる
-    if @community.save
-      binding.pry
+    if @community.valid?
+      current_user.communities.create!(name: community_create_params, owner: current_user)
       flash[:primary] = "#{@community.name}コミュニティーを作成しました。"
       redirect_to communities_path
     else
+      flash.now[:danger] = "#{@community.name}コミュニティーを作成できませんでした。"
       render :new
     end
   end
 
-  # 違い：
-  # - redirect_to: 全部データが消える。　router  を見に行く
+  private
 
-  # - render は flash は使えない?? なぜ flash.now[:]
-
-
-  # - render : 再描写され、new を描写しろよ!
-
-
-  # 保留
-  # def create
-  #   community_name = params[:community][:name]
-
-  #   if community_name.empty?
-  #     flash[:danger] = "入力されていません。"
-  #     return redirect_back(fallback_location: root_path)
-  #   end
-
-  #   unless Community.find_by(name: community_name)
-  #     @community = current_user.communities.create!(name: community_name, owner: current_user)
-  #     flash[:primary] = "#{community_name}コミュニティーを作成しました。"
-
-  #     return redirect_back(fallback_location: root_path)
-  #   end
-
-  #   flash[:warning] = "#{community_name}コミュニティーは既に作成されています。"
-  #   redirect_back(fallback_location: root_path)
-  # end
-
-  # private
-
-  #   # Use callbacks to share common setup or constraints between actions.
-  #   def set_community
-  #     @community = Community.find(params[:id])
-  #   end
-
-  #   # Only allow a list of trusted parameters through.
-  #   def community_params
-  #     params.fetch(:community, {})
-  #   end
+    def community_create_params
+      params.require(:community).permit(:name).values[0]
+    end
 end

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,4 +1,5 @@
 class CommunitiesController < ApplicationController
+  before_action :user_admin, only: [:new]
   PER_PAGE = 10
 
   def new
@@ -27,5 +28,14 @@ class CommunitiesController < ApplicationController
 
     def community_create_params
       params.require(:community).permit(:name).values[0]
+    end
+
+    def user_admin
+      @users = User.all
+      if current_user.admin == false
+        redirect_to communities_path
+      else
+        render action: "new"
+      end
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@
 # Table name: users
 #
 #  id                     :bigint           not null, primary key
+#  admin                  :boolean          default(FALSE)
 #  confirmation_sent_at   :datetime
 #  confirmation_token     :string
 #  confirmed_at           :datetime

--- a/app/views/communities/_form.html.erb
+++ b/app/views/communities/_form.html.erb
@@ -1,0 +1,13 @@
+<%= form_with model:community, local: true, id: "form" do |f| %>
+<div class="row">
+  <div class="col-6 ml-auto">
+    <div class='form-group mt-3 pr-3'>
+      <%= f.label :コミュニティー作成 %>
+      <%= f.text_field :name, class: 'form-control', id: 'form-title', value: value_text, placeholder: 'コミュニティー名を入力' %>
+    </div>
+  </div>
+  <div class="mt-5 pr-3">
+    <%= f.submit "作成", class: 'btn btn-primary create_docuent_button' %>
+  </div>
+</div>
+<% end %>

--- a/app/views/communities/_form.html.erb
+++ b/app/views/communities/_form.html.erb
@@ -1,9 +1,9 @@
 <%= form_with model:community, local: true, id: "form" do |f| %>
 <div class="row">
-  <div class="col-6 ml-auto">
+  <div class="col-6">
     <div class='form-group mt-3 pr-3'>
       <%= f.label :コミュニティー作成 %>
-      <%= f.text_field :name, class: 'form-control', id: 'form-title', value: value_text, placeholder: 'コミュニティー名を入力' %>
+      <%= f.text_field :name, class: 'form-control', id: 'form-title', value: value_text, placeholder: 'コミュニティーをつくろう!' %>
     </div>
   </div>
   <div class="mt-5 pr-3">

--- a/app/views/communities/index.html.erb
+++ b/app/views/communities/index.html.erb
@@ -6,6 +6,7 @@
     </h2>
   </div>
 
+  <!-- unless は可読性 ifで書ける分はかけるとよい  -->
   <% unless current_user.communities.blank? %>
   <% @communities.each do |community| %>
   <div class="row border-bottom mt-3 pb-3">

--- a/app/views/communities/index.html.erb
+++ b/app/views/communities/index.html.erb
@@ -6,7 +6,6 @@
     </h2>
   </div>
 
-  <!-- unless は可読性 ifで書ける分はかけるとよい  -->
   <% unless current_user.communities.blank? %>
   <% @communities.each do |community| %>
   <div class="row border-bottom mt-3 pb-3">

--- a/app/views/communities/index.html.erb
+++ b/app/views/communities/index.html.erb
@@ -27,7 +27,8 @@
   <% else %>
   <div class="border-bottom mt-3 pb-3 community_title">所属なし</div>
   <% end %>
-  <% if user_signed_in? %>
+  <!-- CHANGED: サイドバーにコミュニティ管理機能を追加し、コミュニティ作成画面を実装 -->
+ <% if user_signed_in? %>
     <% if current_user == @user || current_user.admin? %>
       <%= render partial: 'form', locals: { community: @community } %>
     <% end %>

--- a/app/views/communities/index.html.erb
+++ b/app/views/communities/index.html.erb
@@ -27,6 +27,10 @@
   <% else %>
   <div class="border-bottom mt-3 pb-3 community_title">所属なし</div>
   <% end %>
-  <%= render partial: 'form', locals: { community: @community } %>
+  <% if user_signed_in? %>
+    <% if current_user == @user || current_user.admin? %>
+      <%= render partial: 'form', locals: { community: @community } %>
+    <% end %>
+  <% end %>
 </div>
 <%= paginate @communities %>

--- a/app/views/communities/index.html.erb
+++ b/app/views/communities/index.html.erb
@@ -27,5 +27,6 @@
   <% else %>
   <div class="border-bottom mt-3 pb-3 community_title">所属なし</div>
   <% end %>
+  <%= render partial: 'form', locals: { community: @community } %>
 </div>
 <%= paginate @communities %>

--- a/app/views/communities/index.html.erb
+++ b/app/views/communities/index.html.erb
@@ -27,11 +27,5 @@
   <% else %>
   <div class="border-bottom mt-3 pb-3 community_title">所属なし</div>
   <% end %>
-  <!-- CHANGED: サイドバーにコミュニティ管理機能を追加し、コミュニティ作成画面を実装 -->
- <% if user_signed_in? %>
-    <% if current_user == @user || current_user.admin? %>
-      <%= render partial: 'form', locals: { community: @community } %>
-    <% end %>
-  <% end %>
 </div>
 <%= paginate @communities %>

--- a/app/views/communities/new.html.erb
+++ b/app/views/communities/new.html.erb
@@ -1,0 +1,19 @@
+<div class="container create_document_container">
+  <div class="row border-bottom mt-5">
+    <h2>
+      <i class="fas fa-pen-nib sub_title"></i>
+      コミュニティ管理
+    </h2>
+  </div>
+  <p>コミュニティ作成</p>
+    <!-- CHANGED: サイドバーにコミュニティ管理機能を追加し、コミュニティ作成画面を実装
+
+    # POST ではだめ
+    No route matches [POST] "/communities/new"
+     -->
+  <% if user_signed_in? %>
+    <% if current_user == @user || current_user.admin? %>
+      <%= render partial: 'form', locals: { community: @community } %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/communities/new.html.erb
+++ b/app/views/communities/new.html.erb
@@ -2,13 +2,8 @@
   <div class="row border-bottom mt-5">
     <h2>
       <i class="fas fa-cog sub_title"></i>
-      コミュニティ管理
+      コミュニティー管理
     </h2>
   </div>
-  <p>コミュニティ作成</p>
-  <% if user_signed_in? %>
-    <% if current_user == @user || current_user.admin? %>
-      <%= render partial: 'form', locals: { community: @community } %>
-    <% end %>
-  <% end %>
+  <%= render partial: 'form', locals: { community: @community } %>
 </div>

--- a/app/views/communities/new.html.erb
+++ b/app/views/communities/new.html.erb
@@ -1,16 +1,11 @@
 <div class="container create_document_container">
   <div class="row border-bottom mt-5">
     <h2>
-      <i class="fas fa-pen-nib sub_title"></i>
+      <i class="fas fa-cog sub_title"></i>
       コミュニティ管理
     </h2>
   </div>
   <p>コミュニティ作成</p>
-    <!-- CHANGED: サイドバーにコミュニティ管理機能を追加し、コミュニティ作成画面を実装
-
-    # POST ではだめ
-    No route matches [POST] "/communities/new"
-     -->
   <% if user_signed_in? %>
     <% if current_user == @user || current_user.admin? %>
       <%= render partial: 'form', locals: { community: @community } %>

--- a/app/views/layouts/_documents_sidebar.html.erb
+++ b/app/views/layouts/_documents_sidebar.html.erb
@@ -17,12 +17,14 @@
     コミュニティ一覧<br>
     <% end %>
   </div>
-  <div class="pt-4">
-    <%= link_to new_community_path, class: "text-decoration-none text-white" do %>
-    <i class="fas fa-cog pb-1"></i><br>
-    コミュニティ管理<br>
-    <% end %>
-  </div>
+  <% if current_user == @user || current_user.admin? %>
+    <div class="pt-4">
+      <%= link_to new_community_path, class: "text-decoration-none text-white" do %>
+      <i class="fas fa-cog fa-3x"></i><br>
+      コミュニティ管理<br>
+      <% end %>
+    </div>
+  <% end %>
   <div class="accordion-inner">
     <div class="accordion-box-side row">
       <button class="btn-menu bg-primary accordion-side"><i class="fas fa-ellipsis-h fa-4x pl-3 text-white"></i></button>

--- a/app/views/layouts/_documents_sidebar.html.erb
+++ b/app/views/layouts/_documents_sidebar.html.erb
@@ -17,6 +17,12 @@
     コミュニティ一覧<br>
     <% end %>
   </div>
+  <div class="pt-4">
+    <%= link_to new_community_path, class: "text-decoration-none text-white" do %>
+    <i class="fas fa-cog pb-1"></i><br>
+    コミュニティ管理<br>
+    <% end %>
+  </div>
   <div class="accordion-inner">
     <div class="accordion-box-side row">
       <button class="btn-menu bg-primary accordion-side"><i class="fas fa-ellipsis-h fa-4x pl-3 text-white"></i></button>

--- a/app/views/layouts/_documents_sidebar.html.erb
+++ b/app/views/layouts/_documents_sidebar.html.erb
@@ -17,7 +17,7 @@
     コミュニティ一覧<br>
     <% end %>
   </div>
-  <% if current_user == @user || current_user.admin? %>
+  <% if current_user.admin? %>
     <div class="pt-4">
       <%= link_to new_community_path, class: "text-decoration-none text-white" do %>
       <i class="fas fa-cog fa-3x"></i><br>

--- a/db/migrate/20210615124426_add_column_to_user.rb
+++ b/db/migrate/20210615124426_add_column_to_user.rb
@@ -1,0 +1,5 @@
+class AddColumnToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_02_133000) do
+ActiveRecord::Schema.define(version: 2021_06_15_124426) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,6 +106,7 @@ ActiveRecord::Schema.define(version: 2021_06_02_133000) do
     t.string "unconfirmed_email"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "admin", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,6 +3,7 @@
 # Table name: users
 #
 #  id                     :bigint           not null, primary key
+#  admin                  :boolean          default(FALSE)
 #  confirmation_sent_at   :datetime
 #  confirmation_token     :string
 #  confirmed_at           :datetime

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,7 @@
 # Table name: users
 #
 #  id                     :bigint           not null, primary key
+#  admin                  :boolean          default(FALSE)
 #  confirmation_sent_at   :datetime
 #  confirmation_token     :string
 #  confirmed_at           :datetime


### PR DESCRIPTION
## 概要
- タイトル通り


## タスク内容

- コミュニティ登録機能
- コミュニティ管理画面の作成
- 管理者権限付与するカラム追加
- 管理者権限持ちユーザのみが、コミュニティ作成できるように調整


## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub の Files changed で差分を確認
- [x] 影響し得る範囲のローカル環境での動作確認


## 実装画面


<img width="1434" alt="community_setting_view" src="https://user-images.githubusercontent.com/34918376/122311884-1a441400-cf4e-11eb-8b29-1229e8314d49.png">



## その他参考情報
### 実装する上で参考にしたサイト
- [[初心者]Railsで管理者権限付与してみた](https://qiita.com/NZTK/items/7868b2897ff1c46ee338)
- [一般ユーザーと管理ユーザー用のcontrollerを分ける](https://qiita.com/tanutanu/items/7ce8826615f1af605164#%E4%B8%80%E8%88%AC%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E3%81%A8%E7%AE%A1%E7%90%86%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E7%94%A8%E3%81%AEcontroller%E3%82%92%E5%88%86%E3%81%91%E3%82%8B)

### その他
- 【現状】管理者付与は、コンソール上でのみ操作できる。
    👉. 今後、画面上で作成して管理者付与できる流れで考えています。
