### PR TITLE
コミュニティ作成時のバリテーションエラーを調整

### DIFF
--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -15,7 +15,7 @@ class CommunitiesController < ApplicationController
     @community = current_user.communities.new(community_create_params.merge(owner: current_user))
 
     if @community.valid?
-      @community = current_user.communities.create!(community_create_params.merge(owner: current_user))
+      current_user.communities.create!(community_create_params.merge(owner: current_user))
       flash[:primary] = "#{@community.name}コミュニティーを作成しました。"
       redirect_to communities_path
     else

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -15,11 +15,10 @@ class CommunitiesController < ApplicationController
     @community = current_user.communities.new(community_create_params.merge(owner: current_user))
 
     if @community.valid?
-      current_user.communities.create!(community_create_params.merge(owner: current_user))
+      @community = current_user.communities.create!(community_create_params.merge(owner: current_user))
       flash[:primary] = "#{@community.name}コミュニティーを作成しました。"
       redirect_to communities_path
     else
-      flash.now[:danger] = "#{@community.name}コミュニティーを作成できませんでした。"
       render :new
     end
   end

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -180,3 +180,8 @@ th, td {
   color: white;
   font-size: 0.9rem;
 }
+
+// エラーフォーマット
+.error_format {
+  color: red;
+}

--- a/app/views/communities/_form.html.erb
+++ b/app/views/communities/_form.html.erb
@@ -4,6 +4,7 @@
     <div class='form-group mt-3 pr-3'>
       <%= f.label :コミュニティー作成 %>
       <%= f.text_field :name, class: 'form-control', id: 'form-title', value: value_text, placeholder: 'コミュニティーをつくろう!' %>
+      <%= render partial: 'validation', locals: { community: @community } %>
     </div>
   </div>
   <div class="mt-5 pr-3">

--- a/app/views/communities/_validation.erb
+++ b/app/views/communities/_validation.erb
@@ -1,14 +1,3 @@
-<% community_error_val = community.errors.values[0] %>
-<% name = "コミュニティー名" %>
-
-<% if community.errors.any? %>
-  <div>
-    <% if community.name == "" %>
-      <p class="error_format"><%= name + community_error_val %>！</p>
-    <% elsif community.name.length > 50 %>
-      <p class="error_format"><%= name + community_error_val %>！</p>
-    <% else %>
-      <p class="error_format"><%= community.name + community_error_val %>！</p>
-    <% end %>
-  </div>
+<% community.errors.full_messages.each do |msg| %>
+  <p class="error_format"><%= msg %>！</p>
 <% end %>

--- a/app/views/communities/_validation.erb
+++ b/app/views/communities/_validation.erb
@@ -1,0 +1,14 @@
+<% community_error_val = community.errors.values[0] %>
+<% name = "コミュニティー名" %>
+
+<% if community.errors.any? %>
+  <div>
+    <% if community.name == "" %>
+      <p class="error_format"><%= name + community_error_val %>！</p>
+    <% elsif community.name.length > 50 %>
+      <p class="error_format"><%= name + community_error_val %>！</p>
+    <% else %>
+      <p class="error_format"><%= community.name + community_error_val %>！</p>
+    <% end %>
+  </div>
+<% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -214,3 +214,7 @@ ja:
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
     pm: 午後
+  activerecord:
+    attributes:
+      community:
+        name: コミュニティー名


### PR DESCRIPTION
## 概要
- タイトル通り


## タスク内容
- バリテーションエラーのflash を削除
- バリテーションエラー用にファイルを作成
- バリテーションエラー文字のスタイル調整

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub の Files changed で差分を確認
- [x] 影響し得る範囲のローカル環境での動作確認


## 実装画面

![community_validation_error](https://user-images.githubusercontent.com/34918376/123087434-80a1c880-d45f-11eb-80b8-84c15dd9ec97.gif)

## その他参考情報
### 実装する上で参考にしたサイト
- [Rails エラーメッセージの出し方　バリデーションエラー](https://qiita.com/nakanishi03/items/d1be27c74c98855423ab)
- [ActiveRecordのvalidatesで表示されるエラーメッセージのフォーマットを変更する](https://qiita.com/okeicalm/items/9638250ddfb361d80a16#1-attribute%E5%90%8D%E3%82%92%E6%97%A5%E6%9C%AC%E8%AA%9E%E3%81%AB%E3%81%99%E3%82%8B)


